### PR TITLE
Feat/tcle form improvements

### DIFF
--- a/pages/form-answer/index.tsx
+++ b/pages/form-answer/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { GET_FORMATTED_FORM_SHOW, GET_USER_RESULT_FROM_FORM_RES } from "../../src/pages/form-answer/type";
 import Base from "@components/base-layout/index";
 import { useEffect, useState } from "react";
+import { useSnackbar } from "notistack";
 import FormAnswerService from "../../src/pages/form-answer/service";
 import SimpleForm from "@components/form/simple/index";
 import { ID } from "src/core/types";
@@ -16,17 +17,29 @@ export default function Index() {
     const router = useRouter();
     const [formId, setFormId] = React.useState<ID>(Number(router.query.formId));
 
+    const { enqueueSnackbar } = useSnackbar();
     const formAnwerService = new FormAnswerService();
     const [formattedForm, setFormattedForm] = useState<GET_FORMATTED_FORM_SHOW>();
     const [isOpenFormResult, setIsOpenFormResult] = useState<boolean>(false);
     const [formThanks, setFormThanks] = useState(false);
     const [formResult, setFormResult] = useState<GET_USER_RESULT_FROM_FORM_RES | null>();
 
+    function hasSignedRequiredTerm(id: number): boolean {
+        const requiredKey = [1, 3, 4].includes(id) ? 'tcle_TCLEPROF' : 'tcle_TCLE';
+        return sessionStorage.getItem(requiredKey) === '1';
+    }
+
     useEffect(() => {
         if (!router.isReady) return;
 
-        setFormId(Number(router.query.formId));
-    }, [router.isReady, router.query.formId]);
+        const id = Number(router.query.formId);
+        setFormId(id);
+
+        if (!hasSignedRequiredTerm(id)) {
+            enqueueSnackbar("Você precisa assinar os termos obrigatórios antes de responder o formulário.", { variant: "warning" });
+            router.replace(routerEnum.FORM);
+        }
+    }, [router.isReady, router.query.formId, router, enqueueSnackbar]);
 
     useEffect(() => {
         if (formId === null || Number.isNaN(formId)) return;

--- a/pages/form/index.tsx
+++ b/pages/form/index.tsx
@@ -1,5 +1,6 @@
 import Base from "@components/base-layout/index";
-import { Avatar, Box, Button, Typography, useMediaQuery } from "@mui/material";
+import Image from "next/image";
+import { useMediaQuery } from "@mui/material";
 import FormService from "../../src/pages/form/service";
 import React, { useEffect, useRef, useState } from "react";
 import { INDEX_RES } from "../../src/pages/form/type";
@@ -8,7 +9,6 @@ import { ID } from "src/core/types";
 import router from "next/router";
 import { localStorageKeyEnum, routerEnum } from "src/core/enums";
 import NotFound from "@components/not-found/index";
-import { theme } from "src/core/theme";
 import FormAnswerService from "src/pages/form-answer/service";
 import NewMenu from "@components/newMenu/index";
 import FooterMain from "@components/footer/main/index";
@@ -79,86 +79,173 @@ export default function Index() {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    const ff = {
+        display: "'Lora', Georgia, serif",
+        body: "'Source Sans 3', -apple-system, BlinkMacSystemFont, sans-serif",
+    };
+    const C = {
+        primary: '#6D141A',
+        secondary: '#921c22',
+        bg: '#FAF7F2',
+        white: '#fff',
+        text: '#1c1917',
+        muted: '#a8a29e',
+        border: '#e7e5e4',
+    };
+
     return (
         <Base
             appBarChild={<NewMenu />}
             mainContainerChild={
                 forms ? (
                     forms.length === 0 ? (
-                        <Typography>Sem formularios</Typography>
+                        <div style={{ minHeight: '70vh', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: ff.body, color: C.muted, fontSize: '15px' }}>
+                            Nenhum formulário disponível no momento.
+                        </div>
                     ) : (
-                        <Box
-                            sx={{
-                                background: theme.greyLight,
-                                minHeight: "88vh",
-                                display: "flex",
-                                flexDirection: "column",
-                                justifyContent: "center",
-                            }}
-                        >
-                            <Box
-                                sx={{
-                                    marginY: { xs: "10rem", sm: "7rem" },
-                                    marginX: { xs: "1rem", sm: "2rem" },
-                                    minHeight: { xs: "500px", sm: "500px" },
-                                    minWidth: { xs: "80%" },
-                                    background: theme.greyLight,
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    alignItems: "center",
-                                    overflow: "unset",
-                                }}
-                            >
-                                <Typography
-                                    sx={{
-                                        fontSize: { xs: "h5.fontSize", md: "h4.fontSize" },
-                                        fontWeight: "bold",
-                                    }}
-                                >
+                        <div style={{ backgroundColor: C.bg, minHeight: '88vh', padding: '0 0 80px' }}>
+
+                            {/* Hero header */}
+                            <div style={{
+                                backgroundColor: C.white,
+                                borderBottom: `1px solid ${C.border}`,
+                                padding: '72px 24px 52px',
+                                marginBottom: '48px',
+                                textAlign: 'center',
+                            }}>
+                                <div style={{
+                                    display: 'inline-block', width: '40px', height: '3px',
+                                    background: `linear-gradient(90deg, ${C.primary}, ${C.secondary})`,
+                                    borderRadius: '2px', marginBottom: '20px',
+                                }} />
+                                <h1 style={{
+                                    fontFamily: ff.display,
+                                    fontSize: 'clamp(24px, 3.5vw, 38px)',
+                                    fontWeight: 700,
+                                    color: C.text,
+                                    margin: '0 0 12px',
+                                    letterSpacing: '-0.02em',
+                                    lineHeight: 1.2,
+                                }}>
                                     Questionário Avaliativo
-                                </Typography>
-                                <Box
-                                    sx={{
-                                        paddingTop: "4rem",
-                                        display: "flex",
-                                        alignItems: "center",
-                                        gap: "20px",
-                                        justifyContent: "center",
-                                        flexWrap: "wrap",
-                                    }}
-                                >
-                                    {forms.map((v, i) => (
-                                        <Button
-                                            key={i}
-                                            sx={{
-                                                backgroundColor: theme.primaryColor,
-                                                color: theme.white,
-                                                width: { xs: "100%", sm: "350px" },
-                                                height: "200px",
-                                                borderWidth: "0.5rem",
-                                                borderColor: theme.secundaryColor,
-                                                display: "flex",
-                                                flexDirection: "column",
-                                                gap: "10px",
-                                                fontWeight: "bold",
-                                                "&:hover": {
-                                                    backgroundColor: theme.secundaryColor,
-                                                },
-                                            }}
-                                            onClick={() => handleSelectForm(v.id)}
-                                        >
-                                            <Avatar alt="Logo de Odontologia" src="/logo-transparent.png" sx={{ width: "56", height: "56" }} />
-                                            {v.title}
-                                            <></>
-                                        </Button>
-                                    ))}
-                                </Box>
-                            </Box>
-                            {openTCLE ? <TcleModal idForm={formId} setOpenTCLE={setOpenTCLE} open={openTCLE} goForm={goForm} /> : <></>}
-                        </Box>
+                                </h1>
+                                <p style={{
+                                    fontFamily: ff.body,
+                                    fontSize: '15px',
+                                    color: C.muted,
+                                    margin: 0,
+                                    lineHeight: 1.6,
+                                }}>
+                                    Selecione o formulário que deseja responder
+                                </p>
+                            </div>
+
+                            {/* Cards grid */}
+                            <div style={{
+                                maxWidth: '900px',
+                                margin: '0 auto',
+                                padding: '0 24px',
+                                display: 'grid',
+                                gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+                                gap: '20px',
+                            }}>
+                                {forms.map((v, i) => (
+                                    <button
+                                        key={i}
+                                        onClick={() => handleSelectForm(v.id)}
+                                        style={{
+                                            backgroundColor: C.white,
+                                            border: `1.5px solid ${C.border}`,
+                                            borderRadius: '16px',
+                                            padding: '28px 24px',
+                                            cursor: 'pointer',
+                                            textAlign: 'left',
+                                            display: 'flex',
+                                            flexDirection: 'column',
+                                            gap: '16px',
+                                            transition: 'all 0.2s ease',
+                                            boxShadow: '0 1px 4px rgba(0,0,0,0.04)',
+                                            fontFamily: ff.body,
+                                        }}
+                                        onMouseEnter={e => {
+                                            const el = e.currentTarget;
+                                            el.style.borderColor = C.primary;
+                                            el.style.boxShadow = '0 8px 24px rgba(109,20,26,0.12)';
+                                            el.style.transform = 'translateY(-2px)';
+                                        }}
+                                        onMouseLeave={e => {
+                                            const el = e.currentTarget;
+                                            el.style.borderColor = C.border;
+                                            el.style.boxShadow = '0 1px 4px rgba(0,0,0,0.04)';
+                                            el.style.transform = 'translateY(0)';
+                                        }}
+                                    >
+                                        {/* Icon */}
+                                        <div style={{
+                                            width: '56px', height: '56px', borderRadius: '12px',
+                                            backgroundColor: '#6D141A',
+                                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                            flexShrink: 0, overflow: 'hidden',
+                                        }}>
+                                            <Image src="/logo-transparent.png" alt="Logo" width={44} height={44} style={{ objectFit: 'contain' }} />
+                                        </div>
+
+                                        {/* Content */}
+                                        <div style={{ flex: 1 }}>
+                                            <p style={{
+                                                fontSize: '0.9rem',
+                                                fontWeight: 700,
+                                                color: C.text,
+                                                margin: '0 0 6px',
+                                                lineHeight: 1.4,
+                                            }}>
+                                                {v.title}
+                                            </p>
+                                            <p style={{
+                                                fontSize: '0.78rem',
+                                                color: C.muted,
+                                                margin: '0 0 6px',
+                                                lineHeight: 1.5,
+                                            }}>
+                                                Clique para iniciar o preenchimento
+                                            </p>
+                                            <p style={{
+                                                fontSize: '0.72rem',
+                                                color: '#b45309',
+                                                margin: 0,
+                                                lineHeight: 1.4,
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: '4px',
+                                            }}>
+                                                <svg width="11" height="11" fill="none" viewBox="0 0 24 24" stroke="#b45309" strokeWidth={2}>
+                                                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                                                </svg>
+                                                Requer assinatura de termos
+                                            </p>
+                                        </div>
+
+                                        {/* Arrow */}
+                                        <div style={{
+                                            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                            borderTop: `1px solid ${C.border}`, paddingTop: '12px', marginTop: '4px',
+                                        }}>
+                                            <span style={{ fontSize: '0.72rem', fontWeight: 700, color: C.primary, letterSpacing: '0.05em' }}>
+                                                INICIAR
+                                            </span>
+                                            <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke={C.primary} strokeWidth={2.5}>
+                                                <path strokeLinecap="round" strokeLinejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                                            </svg>
+                                        </div>
+                                    </button>
+                                ))}
+                            </div>
+
+                            <TcleModal idForm={formId} setOpenTCLE={setOpenTCLE} open={openTCLE} goForm={goForm} />
+                        </div>
                     )
                 ) : (
-                    <div></div>
+                    <div style={{ minHeight: '70vh' }} />
                 )
             }
             footerChild={<FooterMain />}

--- a/src/components/answer/open/index.tsx
+++ b/src/components/answer/open/index.tsx
@@ -19,23 +19,30 @@ export default function Index(props: TPROPS) {
 			<input
 				className="gestbucal-input"
 				type="text"
+				placeholder={props.placeholder || 'Digite sua resposta...'}
 				onChange={(e) => handleAnswerQuestion(e.target.value)}
 				onBlur={(e) => handleAnswerQuestion(e.target.value)}
 				style={{
 					width: '100%',
-					padding: '10px 0',
+					padding: '10px 12px',
 					fontSize: '15px',
 					fontFamily: "'Source Sans 3', -apple-system, sans-serif",
 					color: '#1c1917',
-					background: 'transparent',
-					border: 'none',
-					borderBottom: '1.5px solid #e7e5e4',
+					background: '#ffffff',
+					border: '1.5px solid #d1d5db',
+					borderRadius: '8px',
 					outline: 'none',
 					boxSizing: 'border-box',
-					transition: 'border-color 0.2s',
+					transition: 'border-color 0.2s, box-shadow 0.2s',
 				}}
-				onFocus={(e) => { e.currentTarget.style.borderBottomColor = '#6D141A'; }}
-				onBlurCapture={(e) => { e.currentTarget.style.borderBottomColor = '#e7e5e4'; }}
+				onFocus={(e) => {
+					e.currentTarget.style.borderColor = '#6D141A';
+					e.currentTarget.style.boxShadow = '0 0 0 3px rgba(109,20,26,0.1)';
+				}}
+				onBlurCapture={(e) => {
+					e.currentTarget.style.borderColor = '#d1d5db';
+					e.currentTarget.style.boxShadow = 'none';
+				}}
 			/>
 		</>
 	);

--- a/src/components/answer/open/type.ts
+++ b/src/components/answer/open/type.ts
@@ -3,5 +3,6 @@ import { QUESTION_ANSWER } from '../../question/type';
 
 export type TPROPS = {
 	formQuestionFormRegisterId: ID;
+	placeholder?: string;
 	onAnswerQuestion: (value: QUESTION_ANSWER) => void;
 };

--- a/src/components/footer/main/index.tsx
+++ b/src/components/footer/main/index.tsx
@@ -1,123 +1,79 @@
-import { Box, List, ListItem, ListItemButton, Typography } from "@mui/material";
-import { theme } from "src/core/theme";
-import { TPROPS } from "./type";
-import { containerBodyTypeEnum, routerEnum } from "src/core/enums";
+import { routerEnum } from "src/core/enums";
 import { useRouter } from "next/router";
 
-const infoList = [
-    {
-        title: "Sobre",
-        items: [
-            {
-                title: "Quem somos?",
-                url: routerEnum.TEAM,
-            },
-            {
-                title: "O que é GestBucal",
-                url: routerEnum.PROJECT,
-            },
-            {
-                title: "TCLE",
-                url: routerEnum.TCLE,
-            },
-        ],
-    },
-    {
-        title: "Endereço",
-        items: [
-            {
-                title: "Avenida Prof. Moraes Rego, 1235\nCidade Universitária\nRecife PE, 50670-901",
-                url: containerBodyTypeEnum.DIRECTION,
-            },
-        ],
-    },
-    {
-        title: "Suporte",
-        items: [
-            {
-                title: "Central SAC | +55(81)3194-4900\nDuvidas | +55(81)3038-6405",
-                url: routerEnum.CONTACTUS,
-            },
-        ],
-    },
+const ff = { body: "'Source Sans 3', -apple-system, BlinkMacSystemFont, sans-serif" };
+
+const links = [
+    { label: "quem somos", url: routerEnum.TEAM },
+    { label: "faq",        url: routerEnum.FAQ },
+    { label: "contato",    url: routerEnum.CONTACTUS },
+    { label: "tcle",       url: routerEnum.TCLE },
+    { label: "acervo",     url: "/collection" },
 ];
 
 export default function Index() {
     const router = useRouter();
 
-    function handleClick(url: string) {
-        router.push(url);
-    }
-
     return (
-        <Box
-            sx={{
-                display: "flex",
-                flexDirection: "column",
-                justifyContent: "center",
-                alignItems: "center",
-                backgroundColor: theme.primaryColor,
-                width: "100%",
-            }}
-        >
-            <Box
-                sx={{
-                    display: "flex",
-                    flexWrap: "wrap",
-                    justifyContent: "center",
-                }}
-            >
-                {infoList.map((info, index) => (
-                    <Typography
-                        key={index}
-                        variant={"subtitle1"}
-                        sx={{
-                            color: theme.white,
-                            textTransform: "uppercase",
-                            textAlign: "center",
+        <footer style={{
+            backgroundColor: '#6D141A',
+            width: '100%',
+            padding: '0 32px',
+            height: '44px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+        }}>
+            {/* Left — brand */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.7)" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 9.75L12 3l9 6.75V21a1 1 0 01-1 1H4a1 1 0 01-1-1V9.75z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 21V12h6v9" />
+                </svg>
+                <span style={{
+                    fontFamily: ff.body,
+                    fontSize: '13px',
+                    fontStyle: 'italic',
+                    color: 'rgba(255,255,255,0.85)',
+                    letterSpacing: '0.01em',
+                }}>
+                    GESTBUCAL SD &copy; 2023–{new Date().getFullYear()}
+                </span>
+            </div>
+
+            {/* Center — nav links */}
+            <nav style={{ display: 'flex', alignItems: 'center', gap: '28px' }}>
+                {links.map((link) => (
+                    <button
+                        key={link.label}
+                        onClick={() => router.push(link.url)}
+                        style={{
+                            background: 'none',
+                            border: 'none',
+                            cursor: 'pointer',
+                            fontFamily: ff.body,
+                            fontSize: '13px',
+                            color: 'rgba(255,255,255,0.82)',
+                            padding: 0,
+                            transition: 'color 0.15s ease',
                         }}
+                        onMouseEnter={e => { e.currentTarget.style.color = '#fff'; }}
+                        onMouseLeave={e => { e.currentTarget.style.color = 'rgba(255,255,255,0.82)'; }}
                     >
-                        {info.title}
-                        <List disablePadding sx={{ marginX: "1rem" }}>
-                            {info.items.map((item, i) => (
-                                <ListItem
-                                    key={i}
-                                    disablePadding
-                                    sx={{
-                                        marginY: "0.5rem",
-                                        marginX: "1rem",
-                                    }}
-                                >
-                                    <ListItemButton
-                                        style={{
-                                            padding: 0,
-                                            fontSize: "0.8rem",
-                                            fontWeight: "bold",
-                                            color: theme.white,
-                                            whiteSpace: "pre-line",
-                                            marginLeft: "1rem",
-                                        }}
-                                        onClick={() => handleClick(item.url)}
-                                    >
-                                        {item.title}
-                                    </ListItemButton>
-                                </ListItem>
-                            ))}
-                        </List>
-                    </Typography>
+                        {link.label}
+                    </button>
                 ))}
-            </Box>
-            <span
-                style={{
-                    color: theme.white,
-                    backgroundColor: theme.secundaryColor,
-                    width: "100%",
-                    font: "bold",
-                    textAlign: "center",
-                }}
-            >
-                GESTBUCAL&copy; - 2023
+            </nav>
+
+            {/* Right — SAC */}
+            <span style={{
+                fontFamily: ff.body,
+                fontSize: '13px',
+                color: 'rgba(255,255,255,0.82)',
+                flexShrink: 0,
+            }}>
+                SAC: (81) 3194-4900
             </span>
-        </Box>
+        </footer>
     );
 }

--- a/src/components/form/simple/index.tsx
+++ b/src/components/form/simple/index.tsx
@@ -169,6 +169,11 @@ export default function Index(props: TPROPS) {
     const ids = new Set<ID>(validation.unansweredQuestions.map((q) => q.formQuestionFormRegisterId));
     setErrorIds(ids);
 
+    enqueueSnackbar(
+      `${validation.missingAnswers} ${validation.missingAnswers === 1 ? 'questão precisa' : 'questões precisam'} ser respondida${validation.missingAnswers === 1 ? '' : 's'}.`,
+      { variant: 'warning' }
+    );
+
     const firstId = validation.unansweredQuestions[0]?.formQuestionFormRegisterId;
     if (firstId) {
       const el = document.getElementById(`question-${firstId}`);
@@ -279,6 +284,7 @@ export default function Index(props: TPROPS) {
               index={index}
               question={question}
               isError={errorIds.has(question.formQuestionFormRegisterId)}
+              errorIds={errorIds}
               onAnswerQuestion={(data) => {
                 handleAnswerQuestion(data);
                 setErrorIds((prev) => { const next = new Set(prev); next.delete(question.formQuestionFormRegisterId); return next; });

--- a/src/components/modal/FormResultFeedBack/index.tsx
+++ b/src/components/modal/FormResultFeedBack/index.tsx
@@ -1,22 +1,19 @@
-import { Card, CardContent, Modal, Typography } from "@mui/material";
-import React, {  useEffect } from "react";
+import { Modal } from "@mui/material";
+import React, { useEffect } from "react";
 import { TPROPS } from "./type";
-import Header from "../header/index";
-import ActionArea from "@components/modal/action-area";
 import { theme } from "src/core/theme";
 
-
+const PRIMARY = '#6D141A';
+const ff = "'Source Sans 3', -apple-system, sans-serif";
 
 export default function FormResultFeedBack(props: TPROPS) {
-
-
   useEffect(() => {
     localStorage.setItem("lastFormSubmited", props.formId + "");
   }, [props.formId]);
 
   return (
     <Modal
-      open={props.isOpen} 
+      open={props.isOpen}
       sx={{
         display: "flex",
         alignItems: "center",
@@ -28,45 +25,131 @@ export default function FormResultFeedBack(props: TPROPS) {
         if (props.canSkip) props.onClose();
       }}
     >
-      <Card
-        sx={{
-          backgroundColor: theme.white,
-          borderRadius: theme.borderRadiusEdge,
-          padding: theme.modal.card.padding,
-          minWidth: theme.modal.card.minWidth,
-          margin: "10%",
-          overflow: "auto",
-          maxHeight: "90%",
-        }}
-      >
-        <Header
-          title={`Formulário finalizado`}
-          onClose={() => props.onClose()}
-        />
-        <CardContent>
-          
+      <div style={{
+        backgroundColor: '#fff',
+        borderRadius: '16px',
+        width: '100%',
+        maxWidth: '440px',
+        margin: '0 16px',
+        overflow: 'hidden',
+        boxShadow: '0 20px 60px rgba(0,0,0,0.3)',
+        outline: 'none',
+      }}>
 
-          <Typography
-            sx={{
-              display: "flex",
-              fontSize: "1.5rem",
-              alignItems: "center",
-              justifyContent:"center",
-              marginTop: "3rem",
+        {/* Header */}
+        <div style={{
+          backgroundColor: PRIMARY,
+          padding: '16px 20px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}>
+          <span style={{
+            color: '#fff',
+            fontSize: '1rem',
+            fontWeight: 700,
+            fontFamily: ff,
+            letterSpacing: '0.01em',
+          }}>
+            Formulário finalizado
+          </span>
+          <button
+            onClick={() => props.onClose()}
+            style={{
+              background: 'rgba(255,255,255,0.15)',
+              border: 'none',
+              borderRadius: '50%',
+              width: '28px',
+              height: '28px',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#fff',
+              fontSize: '16px',
+              lineHeight: 1,
+              padding: 0,
             }}
           >
-            AGRADECEMOS A SUA RESPOSTA
-      
-          </Typography>
-    
-          
-        </CardContent>
-      
-        <ActionArea
-          isLoading={false}
-          onConfirm={() => props.onClose()}
-        />
-      </Card>
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{
+          padding: '40px 32px 32px',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '16px',
+        }}>
+          {/* Ícone de sucesso */}
+          <div style={{
+            width: '64px',
+            height: '64px',
+            borderRadius: '50%',
+            backgroundColor: '#f0fdf4',
+            border: '2px solid #86efac',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            <svg width="32" height="32" fill="none" viewBox="0 0 24 24" stroke="#16a34a" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+            </svg>
+          </div>
+
+          <div style={{ textAlign: 'center' }}>
+            <p style={{
+              fontFamily: ff,
+              fontSize: '1.2rem',
+              fontWeight: 700,
+              color: PRIMARY,
+              margin: '0 0 6px',
+              letterSpacing: '0.02em',
+            }}>
+              Agradecemos a sua resposta!
+            </p>
+            <p style={{
+              fontFamily: ff,
+              fontSize: '0.9rem',
+              color: '#6b7280',
+              margin: 0,
+              lineHeight: 1.5,
+            }}>
+              Suas respostas foram registradas com sucesso.
+            </p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          padding: '0 32px 24px',
+          display: 'flex',
+          justifyContent: 'flex-end',
+        }}>
+          <button
+            onClick={() => props.onClose()}
+            style={{
+              backgroundColor: PRIMARY,
+              color: '#fff',
+              border: 'none',
+              borderRadius: '30px',
+              padding: '10px 32px',
+              fontSize: '0.95rem',
+              fontWeight: 600,
+              fontFamily: ff,
+              cursor: 'pointer',
+              transition: 'background-color 200ms',
+              boxShadow: '0 4px 12px rgba(109,20,26,0.25)',
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#921c22'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = PRIMARY; }}
+          >
+            Confirmar
+          </button>
+        </div>
+      </div>
     </Modal>
   );
 }

--- a/src/components/newMenu/index.tsx
+++ b/src/components/newMenu/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { localStorageKeyEnum, routerEnum } from 'src/core/enums';
 import LoginModal from '@components/modal/log-in/index';
@@ -181,7 +182,7 @@ export default function Index() {
 
 					{/* Logo */}
 					<button onClick={() => router.push(routerEnum.INITIAL)} style={{ ...btnBase, display: 'flex', alignItems: 'center', gap: '10px', background: 'transparent', padding: 0 }}>
-						<img src="/logo-transparent.png" alt="GestBucal" style={{ width: '38px', height: '38px', borderRadius: '50%', border: '2px solid rgba(255,255,255,0.2)' }} />
+						<Image src="/logo-transparent.png" alt="GestBucal" width={38} height={38} style={{ borderRadius: '50%', border: '2px solid rgba(255,255,255,0.2)' }} />
 						<span style={{ fontFamily: ff.display, color: '#fff', fontWeight: 700, fontSize: '19px' }}>
 							GestBucal<span style={{ color: 'rgba(255,255,255,0.35)', fontWeight: 300, marginLeft: '4px' }}>SD</span>
 						</span>

--- a/src/components/newMenu/itensMenu.ts
+++ b/src/components/newMenu/itensMenu.ts
@@ -12,7 +12,6 @@ export const itemsMenu: itemsListType[] = [
 ]
 
 export const itemsDrawer: MENU_ITEM[] = [
-  { id: 0, title: "Questionário Inicial", url: routerEnum.QUESTION },
   { id: 1, title: "Questionários", url: routerEnum.FORM },
   { id: 3, title: "Planeja SD - Teórico", url: routerEnum.PLANEJA },
   { id: 4, title: "Planeja SD - Pratico", url: routerEnum.PLANEJA_PRATICO,},    

--- a/src/components/question/index.tsx
+++ b/src/components/question/index.tsx
@@ -54,7 +54,7 @@ export default function Index(props: TPROPS) {
     }, []);
 
     if (!props.parent || canShow) {
-        const hasError = props.isError && !props.parent;
+        const hasError = !!(props.isError || props.errorIds?.has(props.question.formQuestionFormRegisterId));
         return (
             <div
                 id={`question-${props.question.formQuestionFormRegisterId}`}
@@ -74,7 +74,7 @@ export default function Index(props: TPROPS) {
                         fontFamily: ff.body,
                         color: C.primary,
                         lineHeight: 1.55,
-                        margin: '0 0 20px',
+                        margin: props.question.completionMessage?.trim() ? '0 0 4px' : '0 0 16px',
                     }}>
                         {props.parent?.formQuestionFormRegisterId === 234 ? (
                             <>{props.question.title}</>
@@ -82,9 +82,22 @@ export default function Index(props: TPROPS) {
                             <>{props.index + 1} - {props.question.title}</>
                         )}
                     </p>
+                    {props.question.completionMessage?.trim() && (
+                        <p style={{
+                            fontSize: '14px',
+                            fontWeight: 400,
+                            fontFamily: ff.body,
+                            color: '#6b7280',
+                            lineHeight: 1.5,
+                            margin: '0 0 16px',
+                        }}>
+                            {props.question.completionMessage}
+                        </p>
+                    )}
                     {props.question.choices.length === 0 ? (
                         <OpenAnswer
                             formQuestionFormRegisterId={props.question.formQuestionFormRegisterId}
+                            placeholder={props.question.completionMessage || undefined}
                             onAnswerQuestion={(data) => {
                                 handleAnswerQuestion(data);
                             }}
@@ -156,12 +169,13 @@ export default function Index(props: TPROPS) {
                             style={{ display: 'block', margin: '0 auto', maxWidth: '100%', height: 'auto' }}
                         />
                     )}
-                    {props.question.childrenQuestion.reverse().map((child, index) => (
+                    {(props.question.childrenQuestion ?? []).slice().reverse().map((child, index) => (
                         <Index
                             key={index}
                             index={index}
                             parent={props.question}
                             question={child}
+                            errorIds={props.errorIds}
                             onAnswerQuestion={(data) => {
                                 props.onAnswerQuestion(data);
                             }}
@@ -174,4 +188,5 @@ export default function Index(props: TPROPS) {
             </div>
         );
     }
+    return null;
 }

--- a/src/components/question/type.ts
+++ b/src/components/question/type.ts
@@ -6,6 +6,7 @@ export type TPROPS = {
 	parent?: QUESTION;
 	question: QUESTION;
 	isError?: boolean;
+	errorIds?: Set<ID>;
 	onAnswerQuestion: (value: QUESTION_ANSWER) => void;
 	onHideQuestion: (formQuestionFormRegisterId: ID) => void;
 };

--- a/src/components/tcle/exportpdf.tsx
+++ b/src/components/tcle/exportpdf.tsx
@@ -21,7 +21,7 @@ function replaceInputForValue(node: Element, myArray: typeStyles[]) {
     } else {
       const textNode = document.createElement("span");
       textNode.textContent = element.value || "[Campo vazio]";
-      node.replaceChild(textNode, element);
+      element.parentNode.replaceChild(textNode, element);
     }
   });
 }

--- a/src/components/tcle/index.tsx
+++ b/src/components/tcle/index.tsx
@@ -1,7 +1,7 @@
-import { Dispatch, useEffect, useRef, useState } from "react";
-import { Modal, Box, Checkbox, useMediaQuery } from "@mui/material";
-import { Block, Check } from "@mui/icons-material";
-import { CardContainer, CardTitle, DocumentContainer, DocumentTitle, TermsButton, TermsButtonContainer, TermsContainer, TermsText } from "./styled";
+import React, { Dispatch, useEffect, useRef, useState } from "react";
+import { Modal, Box, useMediaQuery, CircularProgress } from "@mui/material";
+import { ArrowBack, ArrowForward } from "@mui/icons-material";
+import { CardContainer, CardTitle, DocumentContainer, DocumentTitle, TermScrollArea, TermsButton, TermsButtonContainer, TermsContainer, TermsText } from "./styled";
 import TCLE from "./tcle-document/TCLE";
 import TALEU18 from "./tcle-document/TALEU18";
 import TALEU13 from "./tcle-document/TALEU13";
@@ -33,73 +33,114 @@ export type DataTerm = {
     form?: number;
 };
 
+type TermRef = { getStates: () => Promise<DataTerm> };
+type TermRefNew = { getStatesNew: () => Promise<DataTerm> };
+
+const Badge = ({ checked }: { checked: boolean }) => (
+    <span style={{
+        fontSize: '0.68rem', fontWeight: 700, padding: '3px 10px', borderRadius: '100px',
+        flexShrink: 0, letterSpacing: '0.03em',
+        backgroundColor: checked ? 'rgba(22,163,74,0.1)' : 'rgba(217,119,6,0.1)',
+        color: checked ? '#16a34a' : '#d97706',
+        border: `1px solid ${checked ? 'rgba(22,163,74,0.25)' : 'rgba(217,119,6,0.25)'}`,
+    }}>
+        {checked ? '✓ Concluído' : '● Pendente'}
+    </span>
+);
+
+const DocIcon = ({ checked }: { checked: boolean }) => (
+    <span style={{
+        width: 38, height: 38, borderRadius: '10px', flexShrink: 0,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        backgroundColor: checked ? '#6D141A' : 'rgba(109,20,26,0.08)',
+        transition: 'background-color 0.2s',
+    }}>
+        {checked ? (
+            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="#fff" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+        ) : (
+            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="#6D141A" strokeWidth={1.8}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+        )}
+    </span>
+);
+
 export default function TcleModal(props: Props) {
-    const TCLERef = useRef(null);
-    const TCLE2Ref = useRef(null);
-    const TALERef = useRef(null);
-    const TALEURef = useRef(null);
-    const TCLEPROFRef = useRef(null);
-    const [open, setOpen] = useState(true);
+    const TCLERef = useRef<TermRef>(null);
+    const TCLE2Ref = useRef<TermRef>(null);
+    const TALERef = useRef<TermRef>(null);
+    const TALEURef = useRef<TermRefNew>(null);
+    const TCLEPROFRef = useRef<TermRef>(null);
     const [openForm, setOpenForm] = useState(false);
     const [checkedTCLE, setCheckedTCLE] = useState(false);
-    const [dataTCLE, setDataTCLE] = useState<DataTerm>(null);
+    const [dataTCLE, setDataTCLE] = useState<DataTerm | null>(null);
+    const [checkedTCLE2, setCheckedTCLE2] = useState(false);
+    const [dataTCLE2, setDataTCLE2] = useState<DataTerm | null>(null);
+    const [checkedTCLEPROF, setCheckedTCLEPROF] = useState(false);
+    const [dataTCLEPROF, setDataTCLEPROF] = useState<DataTerm | null>(null);
     const [checkedTALE18, setCheckedTALE18] = useState(false);
-    const [dataTALE, setDataTALE] = useState<DataTerm>(null);
+    const [dataTALE, setDataTALE] = useState<DataTerm | null>(null);
     const [checkedTALEUNDER13, setCheckedTALEUNDER13] = useState(false);
-    const [dataTALEU, setDataTALEU] = useState<DataTerm>(null);
+    const [dataTALEU, setDataTALEU] = useState<DataTerm | null>(null);
     const largeQuery = useMediaQuery("(min-width:720px)");
     const snackBar = useSnackbar();
 
     const [termSelected, setTermSelected] = useState<"TCLE" | "TCLE2" | "TALE18" | "TALEU13" | "TCLEPROF">("TCLEPROF");
+    const [hasReadTerm, setHasReadTerm] = useState(false);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        setCheckedTCLE(sessionStorage.getItem('tcle_TCLE') === '1');
+        setCheckedTCLE2(sessionStorage.getItem('tcle_TCLE2') === '1');
+        setCheckedTCLEPROF(sessionStorage.getItem('tcle_TCLEPROF') === '1');
+        setCheckedTALE18(sessionStorage.getItem('tcle_TALE18') === '1');
+        setCheckedTALEUNDER13(sessionStorage.getItem('tcle_TALEU13') === '1');
+    }, []);
+
+    useEffect(() => { setHasReadTerm(false); }, [termSelected]);
+
+    useEffect(() => { if (!props.open) setOpenForm(false); }, [props.open]);
+
+
+    const handleTermScroll = (e: React.UIEvent<HTMLDivElement>) => {
+        const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
+        if (scrollTop + clientHeight >= scrollHeight - 30) setHasReadTerm(true);
+    };
 
     const confirmTerm = async () => {
-        if (termSelected == "TCLE") {
-            const states = await TCLERef.current.getStates();
-            if (states) {
-                setCheckedTCLE(true);
-                setOpenForm(false);
-                states.form = Number(props.idForm);
-                setDataTCLE(states);
+        setLoading(true);
+        try {
+            let states = null;
+            if (termSelected == "TCLE") {
+                states = await TCLERef.current?.getStates();
+                if (states) { states.form = Number(props.idForm); setDataTCLE(states); setCheckedTCLE(true); sessionStorage.setItem('tcle_TCLE', '1'); }
+            } else if (termSelected == "TCLE2") {
+                states = await TCLE2Ref.current?.getStates();
+                if (states) { states.form = Number(props.idForm); setDataTCLE2(states); setCheckedTCLE2(true); sessionStorage.setItem('tcle_TCLE2', '1'); }
+            } else if (termSelected == "TCLEPROF") {
+                states = await TCLEPROFRef.current?.getStates();
+                if (states) { states.form = Number(props.idForm); setDataTCLEPROF(states); setCheckedTCLEPROF(true); sessionStorage.setItem('tcle_TCLEPROF', '1'); }
+            } else if (termSelected == "TALE18") {
+                states = await TALERef.current?.getStates();
+                if (states) { states.form = Number(props.idForm); setDataTALE(states); setCheckedTALE18(true); sessionStorage.setItem('tcle_TALE18', '1'); }
+            } else if (termSelected == "TALEU13") {
+                states = await TALEURef.current?.getStatesNew();
+                if (states) { states.form = Number(props.idForm); setDataTALEU(states); setCheckedTALEUNDER13(true); sessionStorage.setItem('tcle_TALEU13', '1'); }
             }
-        } else if (termSelected == "TCLE2") {
-            const states = await TCLE2Ref.current.getStates();
-            if (states) {
-                setCheckedTCLE(true);
-                setOpenForm(false);
-                states.form = Number(props.idForm);
-                setDataTCLE(states);
-            }
-        } else if (termSelected == "TCLEPROF") {
-            const states = await TCLEPROFRef.current.getStates();
-            if (states) {
-                setCheckedTCLE(true);
-                setOpenForm(false);
-                states.form = Number(props.idForm);
-                setDataTCLE(states);
-            }
-        } else if (termSelected == "TALE18") {
-            const states = await TALERef.current.getStates();
-            if (states) {
-                setCheckedTALE18(true);
-                setOpenForm(false);
-                states.form = Number(props.idForm);
-                setDataTALE(states);
-            }
-        } else if (termSelected == "TALEU13") {
-            const states = await TALEURef.current.getStatesNew();
-            if (states) {
-                setCheckedTALEUNDER13(true);
-                setOpenForm(false);
-                states.form = Number(props.idForm);
-                setDataTALEU(states);
-            }
+            if (states) setOpenForm(false);
+        } finally {
+            setLoading(false);
         }
     };
 
     async function iCanGo() {
-        if (dataTCLE) {
+        if (dataTCLE || dataTCLEPROF) {
+        const tcleData = dataTCLE ?? dataTCLEPROF;
+            setLoading(true);
             let response = await http.post("/term/send", {
-                tcle: dataTCLE,
+                tcle: tcleData,
                 tale: dataTALE,
                 taleu: dataTALEU,
                 formId: props.idForm,
@@ -110,22 +151,14 @@ export default function TcleModal(props: Props) {
                 props.goForm();
                 props.setOpenTCLE(false);
             } else {
-                type ErrorResponse = {
-                    errors: string[];
-                };
-
+                type ErrorResponse = { errors: string[] };
                 const newResponse = response as unknown as ErrorResponse;
-
-                if (newResponse.errors[0]) {
-                    snackBar.enqueueSnackbar(newResponse.errors[0], {
-                        variant: "error",
-                    });
-                } else {
-                    snackBar.enqueueSnackbar("Houve um erro ao tentar enviar seu termo, tente refazer e mande novamente", {
-                        variant: "error",
-                    });
-                }
+                snackBar.enqueueSnackbar(
+                    newResponse.errors?.[0] ?? "Houve um erro ao tentar enviar seu termo, tente refazer e mande novamente",
+                    { variant: "error" }
+                );
             }
+            setLoading(false);
         } else {
             snackBar.enqueueSnackbar("Você precisa asssinar os termos obrigatorios (*)!", {
                 variant: "warning",
@@ -139,9 +172,9 @@ export default function TcleModal(props: Props) {
                 width: largeQuery ? "60vw" : "100vw",
                 margin: largeQuery ? "auto" : "0",
             }}
-            open={open}
-            onClose={() => setOpen(false)}
-            onKeyDown={(e) => {
+            open={props.open}
+            onClose={() => props.setOpenTCLE(false)}
+            onKeyDown={(e: React.KeyboardEvent) => {
                 if (e.key == "Escape") {
                     props.setOpenTCLE(false);
                 }
@@ -162,73 +195,90 @@ export default function TcleModal(props: Props) {
                     }}
                 >
                     <CardContainer>
-                        <CardTitle>Termo de Consentimento Livre e Esclarecido</CardTitle>
+                        <CardTitle>Termos de Consentimento</CardTitle>
+                        <p style={{ textAlign: 'center', fontSize: '0.8rem', color: '#9ca3af', margin: '0 0 14px', fontFamily: "'Source Sans 3', sans-serif" }}>
+                            Clique em cada termo, leia e assine para continuar
+                        </p>
                         <TermsContainer>
                             <TermsText
-                                style={{
-                                    display: props.idForm == "5" || props.idForm == "6" || props.idForm == "2" ? "" : "none",
-                                }}
-                                onClick={() => {
-                                    setOpenForm(true);
-                                    setTermSelected("TCLE");
-                                }}
+                                $checked={checkedTCLE}
+                                style={{ display: props.idForm == "5" || props.idForm == "6" || props.idForm == "2" ? "" : "none" }}
+                                onClick={() => { setOpenForm(true); setTermSelected("TCLE"); }}
                             >
-                                <Checkbox checked={checkedTCLE} />* TERMO DE CONSENTIMENTO LIVRE E ESCLARECIDO (PARA RESPONSÁVEL LEGAL PELO MENOR)
+                                <DocIcon checked={checkedTCLE} />
+                                <span style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                                    <span style={{ fontSize: '0.85rem', fontWeight: 700, color: checkedTCLE ? '#6D141A' : '#1c1917', lineHeight: 1.3 }}>
+                                        Termo de Consentimento — Responsável Legal
+                                    </span>
+                                    <span style={{ fontSize: '0.75rem', color: '#9ca3af', fontWeight: 400 }}>Para responsável legal pelo menor de 18 anos</span>
+                                </span>
+                                <Badge checked={checkedTCLE} />
                             </TermsText>
                             <TermsText
-                                style={{
-                                    display: props.idForm == "1" || props.idForm == "3" || props.idForm == "4" ? "" : "none",
-                                }}
-                                onClick={() => {
-                                    setOpenForm(true);
-                                    setTermSelected("TCLEPROF");
-                                }}
+                                $checked={checkedTCLEPROF}
+                                style={{ display: props.idForm == "1" || props.idForm == "3" || props.idForm == "4" ? "" : "none" }}
+                                onClick={() => { setOpenForm(true); setTermSelected("TCLEPROF"); }}
                             >
-                                <Checkbox checked={checkedTCLE} />* TERMO DE CONSENTIMENTO LIVRE E ESCLARECIDO – Módulos 1, 2 e 3 - PROFISSIONAIS
+                                <DocIcon checked={checkedTCLEPROF} />
+                                <span style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                                    <span style={{ fontSize: '0.85rem', fontWeight: 700, color: checkedTCLEPROF ? '#6D141A' : '#1c1917', lineHeight: 1.3 }}>
+                                        Termo de Consentimento — Profissionais
+                                    </span>
+                                    <span style={{ fontSize: '0.75rem', color: '#9ca3af', fontWeight: 400 }}>Módulos 1, 2 e 3 · Maiores de 18 anos</span>
+                                </span>
+                                <Badge checked={checkedTCLEPROF} />
                             </TermsText>
                             <TermsText
-                                style={{
-                                    display: props.idForm == "6" || props.idForm == "2" ? "" : "none",
-                                }}
-                                onClick={() => {
-                                    setOpenForm(true);
-                                    setTermSelected("TCLE2");
-                                }}
+                                $checked={checkedTCLE2}
+                                style={{ display: props.idForm == "6" || props.idForm == "2" ? "" : "none" }}
+                                onClick={() => { setOpenForm(true); setTermSelected("TCLE2"); }}
                             >
-                                <Checkbox checked={checkedTCLE} />* TERMO DE CONSENTIMENTO LIVRE E ESCLARECIDO (PARA MAIORES DE 18 ANOS)
+                                <DocIcon checked={checkedTCLE2} />
+                                <span style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                                    <span style={{ fontSize: '0.85rem', fontWeight: 700, color: checkedTCLE2 ? '#6D141A' : '#1c1917', lineHeight: 1.3 }}>
+                                        Termo de Consentimento — Maiores de 18 Anos
+                                    </span>
+                                    <span style={{ fontSize: '0.75rem', color: '#9ca3af', fontWeight: 400 }}>Para maiores de 18 anos ou emancipados</span>
+                                </span>
+                                <Badge checked={checkedTCLE2} />
                             </TermsText>
                             <TermsText
-                                style={{
-                                    display: props.idForm == "6" || props.idForm == "2" ? "" : "none",
-                                }}
-                                onClick={() => {
-                                    setOpenForm(true);
-                                    setTermSelected("TALE18");
-                                }}
+                                $checked={checkedTALE18}
+                                style={{ display: props.idForm == "6" || props.idForm == "2" ? "" : "none" }}
+                                onClick={() => { setOpenForm(true); setTermSelected("TALE18"); }}
                             >
-                                <Checkbox checked={checkedTALE18} /> TERMO DE ASSENTIMENTO LIVRE E ESCLARECIDO (PARA MENORES DE 13 a 18 ANOS)
+                                <DocIcon checked={checkedTALE18} />
+                                <span style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                                    <span style={{ fontSize: '0.85rem', fontWeight: 700, color: checkedTALE18 ? '#6D141A' : '#1c1917', lineHeight: 1.3 }}>
+                                        Termo de Assentimento — 13 a 18 Anos
+                                    </span>
+                                    <span style={{ fontSize: '0.75rem', color: '#9ca3af', fontWeight: 400 }}>Para menores entre 13 e 18 anos</span>
+                                </span>
+                                <Badge checked={checkedTALE18} />
                             </TermsText>
                             <TermsText
-                                style={{
-                                    display: props.idForm == "5" || props.idForm == "2" ? "" : "none",
-                                }}
-                                onClick={() => {
-                                    setOpenForm(true);
-                                    setTermSelected("TALEU13");
-                                }}
+                                $checked={checkedTALEUNDER13}
+                                style={{ display: props.idForm == "5" || props.idForm == "2" ? "" : "none" }}
+                                onClick={() => { setOpenForm(true); setTermSelected("TALEU13"); }}
                             >
-                                <Checkbox checked={checkedTALEUNDER13} /> Termo de Assentimento Livre e Esclarecido | TALE Lúdico (5 a 12 anos)
+                                <DocIcon checked={checkedTALEUNDER13} />
+                                <span style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                                    <span style={{ fontSize: '0.85rem', fontWeight: 700, color: checkedTALEUNDER13 ? '#6D141A' : '#1c1917', lineHeight: 1.3 }}>
+                                        TALE Lúdico — 5 a 12 Anos
+                                    </span>
+                                    <span style={{ fontSize: '0.75rem', color: '#9ca3af', fontWeight: 400 }}>Termo de assentimento para crianças</span>
+                                </span>
+                                <Badge checked={checkedTALEUNDER13} />
                             </TermsText>
                         </TermsContainer>
                     </CardContainer>
                     <TermsButtonContainer>
-                        <TermsButton onClick={() => props.setOpenTCLE(false)}>
-                            <Block />
+                        <TermsButton disabled={loading} onClick={() => props.setOpenTCLE(false)}>
+                            <ArrowBack />
                             Voltar
                         </TermsButton>
-                        <TermsButton onClick={iCanGo}>
-                            Proximo
-                            <Check />
+                        <TermsButton disabled={loading} onClick={iCanGo}>
+                            {loading ? <CircularProgress size={18} color="inherit" /> : <>Próximo <ArrowForward /></>}
                         </TermsButton>
                     </TermsButtonContainer>
                 </Box>
@@ -243,79 +293,48 @@ export default function TcleModal(props: Props) {
                         bgcolor: "background.paper",
                         boxShadow: 24,
                         borderRadius: 3,
-                        p: 4,
+                        p: 2,
+                        px: 3,
                     }}
                 >
                     <DocumentContainer>
-                        {termSelected == "TCLE" ? (
-                            <>
-                                <DocumentTitle>
-                                    TERMO DE CONSENTIMENTO LIVRE E ESCLARECIDO (PARA RESPONSÁVEL LEGAL PELO MENOR DE 18 ANOS)
-                                </DocumentTitle>
-                                <TCLE ref={TCLERef}></TCLE>
-                            </>
-                        ) : (
-                            <></>
+                        {termSelected == "TCLE" && <DocumentTitle>Termo de Consentimento Livre e Esclarecido (Para Responsável Legal pelo Menor de 18 Anos)</DocumentTitle>}
+                        {termSelected == "TALEU13" && <DocumentTitle>Termo de Assentimento Livre e Esclarecido | TALE Lúdico (5 a 12 anos)</DocumentTitle>}
+                        {termSelected == "TALE18" && <DocumentTitle>Termo de Assentimento Livre e Esclarecido (Para Menores de 13 a 18 Anos)</DocumentTitle>}
+                        {termSelected == "TCLE2" && <DocumentTitle>Termo de Consentimento Livre e Esclarecido (Para Maiores de 18 Anos)</DocumentTitle>}
+                        {termSelected == "TCLEPROF" && <DocumentTitle>Termo de Consentimento Livre e Esclarecido – Módulos 1, 2 e 3 - Profissionais</DocumentTitle>}
+
+                        <TermScrollArea onScroll={handleTermScroll}>
+                            <div style={{ display: termSelected == "TCLE" ? "" : "none" }}><TCLE ref={TCLERef} /></div>
+                            <div style={{ display: termSelected == "TALEU13" ? "" : "none" }}><TALEU13 ref={TALEURef} /></div>
+                            <div style={{ display: termSelected == "TALE18" ? "" : "none" }}><TALEU18 ref={TALERef} /></div>
+                            <div style={{ display: termSelected == "TCLE2" ? "" : "none" }}><TCLE2 ref={TCLE2Ref} /></div>
+                            <div style={{ display: termSelected == "TCLEPROF" ? "" : "none" }}><TCLEPROF ref={TCLEPROFRef} /></div>
+                        </TermScrollArea>
+
+                        {!hasReadTerm && (
+                            <p style={{ margin: '6px 0 0', fontSize: '0.8rem', color: '#9ca3af', textAlign: 'center' }}>
+                                Role até o final do documento para continuar
+                            </p>
                         )}
-                        {termSelected == "TALEU13" ? (
-                            <>
-                                <DocumentTitle>Termo de Assentimento Livre e Esclarecido | TALE Lúdico (5 a 12 anos)</DocumentTitle>
-                                <TALEU13 ref={TALEURef}></TALEU13>
-                            </>
-                        ) : (
-                            <></>
-                        )}
-                        {termSelected == "TALE18" ? (
-                            <>
-                                <DocumentTitle>TERMO DE ASSENTIMENTO LIVRE E ESCLARECIDO (PARA MENORES DE 13 a 18 ANOS)</DocumentTitle>
-                                <TALEU18 ref={TALERef}></TALEU18>
-                            </>
-                        ) : (
-                            <></>
-                        )}
-                        {termSelected == "TCLE2" ? (
-                            <>
-                                <DocumentTitle>TERMO DE CONSENTIMENTO LIVRE E ESCLARECIDO (PARA MAIORES DE 18 ANOS)</DocumentTitle>
-                                <TCLE2 ref={TCLE2Ref}></TCLE2>
-                            </>
-                        ) : (
-                            <></>
-                        )}
-                        {termSelected == "TCLEPROF" ? (
-                            <>
-                                <DocumentTitle>TERMO DE CONSENTIMENTO LIVRE E ESCLARECIDO – Módulos 1, 2 e 3 - PROFISSIONAIS</DocumentTitle>
-                                <TCLEPROF ref={TCLEPROFRef}></TCLEPROF>
-                            </>
-                        ) : (
-                            <></>
-                        )}
-                        {/* <DocumentSignatureContainer>
-              <TextField
-                required
-                label="Digite seu nome"
-                type="text"
-                sx={{
-                  backgroundColor: theme.white,
-                }}
-              />
-              <TextField
-                required
-                label="Digite seu email"
-                type="email"
-                sx={{
-                  backgroundColor: theme.white,
-                }}
-              />
-            </DocumentSignatureContainer> */}
                     </DocumentContainer>
                     <TermsButtonContainer>
-                        <TermsButton onClick={(e) => setOpenForm(false)}>
-                            <Block />
+                        <TermsButton disabled={loading} onClick={() => setOpenForm(false)}>
+                            <ArrowBack />
                             Voltar
                         </TermsButton>
-                        <TermsButton onClick={confirmTerm}>
-                            Proximo
-                            <Check />
+                        <TermsButton
+                            disabled={loading || !hasReadTerm}
+                            onClick={hasReadTerm && !loading ? confirmTerm : undefined}
+                            style={{
+                                opacity: hasReadTerm ? 1 : 0.45,
+                                cursor: hasReadTerm && !loading ? 'pointer' : 'not-allowed',
+                            }}
+                        >
+                            {loading
+                                ? <CircularProgress size={18} color="inherit" />
+                                : <>Próximo <ArrowForward /></>
+                            }
                         </TermsButton>
                     </TermsButtonContainer>
                 </Box>

--- a/src/components/tcle/styled.tsx
+++ b/src/components/tcle/styled.tsx
@@ -6,31 +6,66 @@ import { StyleSheet } from "@react-pdf/renderer";
 export const CardContainer = styled.div``;
 
 export const CardTitle = styled.h1`
-  font-size: 2.5vw;
+  font-size: 1.35rem;
   color: ${theme.primaryColor};
   text-align: center;
+  font-weight: 700;
+  font-family: 'Lora', Georgia, serif;
+  margin: 0 0 4px;
+  letter-spacing: -0.01em;
 
   @media (max-width: 768px) {
-    font-size: 8vw;
+    font-size: 5.5vw;
   }
 `;
 
 export const TermsContainer = styled.div`
-  padding: 2% 2%;
   box-sizing: border-box;
-  border-radius: 10px;
-  border: 1px solid gray;
-  margin: 2vh 0 5vh 0;
+  margin: 14px 0 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 `;
 
-export const TermsText = styled.p`
-  font-weight: bolder;
-  color: ${theme.black};
-  font-size: 1vw;
-  margin: 3vh 0 3vh 0;
+export const TermsText = styled.div<{ $checked?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
   cursor: pointer;
+  border: 1.5px solid ${props => props.$checked ? 'rgba(109,20,26,0.25)' : '#ebebeb'};
+  background-color: ${props => props.$checked ? 'rgba(109,20,26,0.04)' : '#fafafa'};
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background-color: ${props => props.$checked ? theme.primaryColor : 'transparent'};
+    border-radius: 12px 0 0 12px;
+    transition: background-color 0.2s;
+  }
+
+  &:hover {
+    border-color: rgba(109,20,26,0.35);
+    background-color: rgba(109,20,26,0.06);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(109,20,26,0.1);
+
+    &::before {
+      background-color: ${theme.primaryColor};
+    }
+  }
+
   @media (max-width: 768px) {
-    font-size: 3vw;
+    padding: 10px 12px;
+    gap: 10px;
   }
 `;
 
@@ -38,56 +73,87 @@ export const TermsButtonContainer = styled.span`
   display: grid;
   column-gap: 10%;
   grid-template-columns: 45% 45%;
+  margin-top: 8px;
 `;
 
 export const TermsButton = styled.button`
   border-radius: 30px;
   background-color: ${theme.primaryColor};
+  color: white;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.5vw;
-  padding: 3% 0;
+  gap: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 12px 0;
+  min-height: 44px;
   border: 0;
-  box-shadow: 5px 5px 5px 0px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   box-sizing: border-box;
   cursor: pointer;
-  transition: 300ms;
+  transition: background-color 200ms, transform 200ms;
 
   &:hover {
-    transform: scaleX(1.05);
+    transform: scaleX(1.03);
     background-color: ${theme.secundaryColor};
   }
 
   @media (max-width: 768px) {
     font-size: 4vw;
+    padding: 10px 0;
   }
 `;
 
 export const DocumentContainer = styled.div`
-  height: 80vh;
+  display: flex;
+  flex-direction: column;
+  height: 75vh;
+  gap: 12px;
 `;
 
-export const DocumentTitle = styled.h1`
-  font-size: 1.5vw;
+export const DocumentTitle = styled.h2`
+  font-size: 1.1vw;
   color: ${theme.primaryColor};
   text-align: center;
+  font-weight: 700;
+  line-height: 1.4;
+  margin: 0;
+  padding-bottom: 12px;
+  border-bottom: 2px solid ${theme.primaryColor};
 
   @media (max-width: 768px) {
-    font-size: 4vw;
+    font-size: 3.5vw;
   }
 `;
 
-export const DocumentData = styled.div`
-  color: black;
-
-  border: 1px solid ${theme.grey};
-  padding: 1%;
-  border-radius: 15px;
-  height: 86%;
+export const TermScrollArea = styled.div`
+  flex: 1;
   overflow-y: auto;
+  border: 1px solid ${theme.grey};
+  border-radius: 10px;
+`;
+
+export const DocumentData = styled.div`
+  padding: 16px 24px;
+  color: black;
+  font-size: 0.88rem;
+  font-family: 'Source Sans 3', -apple-system, BlinkMacSystemFont, sans-serif;
+  line-height: 1.7;
+
   * {
     color: black;
+  }
+
+  ul {
+    padding-left: 1.5em;
+    margin: 0.5em 0;
+  }
+
+  li {
+    margin-bottom: 0.5em;
+    line-height: 1.6;
+    font-size: 0.88rem;
   }
 `;
 

--- a/src/components/tcle/tcle-document/TALEU13.tsx
+++ b/src/components/tcle/tcle-document/TALEU13.tsx
@@ -1,13 +1,10 @@
-import {
+import React, {
   forwardRef,
-  useEffect,
   useImperativeHandle,
-  useRef,
   useState,
 } from "react";
 import { DocumentData } from "../styled";
 import {
-  DocumentLi,
   DocumentParagraphyTitle,
   PD,
   PDInput,
@@ -15,77 +12,63 @@ import {
   TaleImage,
 } from "./styled";
 import { generatePDF } from "../exportpdf";
-import { useSnackbar } from "notistack";
-import { DataTerm, PropsTerm } from "..";
+import { DataTerm } from "..";
+import { maskDate, validateDate } from "src/core/utils/date";
+import { maskPhone, validatePhone } from "src/core/utils/phone";
+import { onlyLetters } from "src/core/utils/text";
+
+const FieldError = ({ msg }: { msg: string }) =>
+  msg ? <span style={{ color: '#dc2626', fontSize: '0.75em', display: 'block', marginTop: '2px', whiteSpace: 'nowrap' }}>{msg}</span> : null;
+
+const FieldWrap = ({ children }: { children: React.ReactNode }) => (
+  <span style={{ display: 'inline-flex', flexDirection: 'column', verticalAlign: 'middle' }}>
+    {children}
+  </span>
+);
 
 const Index = forwardRef((props, ref) => {
   const [nameMinor, setNameMinor] = useState<string>("");
+  const [nameMinorError, setNameMinorError] = useState<string>("");
   const [responsibleAddres, setResponsibleAddres] = useState<string>("");
+  const [responsibleAddresError, setResponsibleAddresError] = useState<string>("");
   const [responsibleNumber, setResponsibleNumber] = useState<string>("");
+  const [responsibleNumberError, setResponsibleNumberError] = useState<string>("");
   const [responsibleEmail, setResponsibleEmail] = useState<string>("");
+  const [emailError, setEmailError] = useState<string>("");
   const [nameResponsible, setNameResponsible] = useState<string>("");
+  const [nameResponsibleError, setNameResponsibleError] = useState<string>("");
   const [local, setLocal] = useState<string>("");
+  const [localError, setLocalError] = useState<string>("");
   const [date, setDate] = useState<string>("");
-  const { enqueueSnackbar } = useSnackbar();
+  const [dateError, setDateError] = useState<string>("");
 
   const isFormValid = () => {
-    if (!nameMinor) {
-      enqueueSnackbar("Preencha o campo Nome do Menor", { variant: "warning" });
-      return false;
-    }
-    if (!responsibleAddres) {
-      enqueueSnackbar("Preencha o campo Endereço do Responsável", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!responsibleNumber) {
-      enqueueSnackbar("Preencha o campo Número do Responsável", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!responsibleEmail) {
-      enqueueSnackbar("Preencha o campo Email do Responsável", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (
-      !responsibleEmail ||
-      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail)
-    ) {
-      enqueueSnackbar("Preencha um e-mail válido para o Responsável", {
-        variant: "warning",
-      });
-      return false;
-    }
+    let valid = true;
 
-    if (!nameResponsible) {
-      enqueueSnackbar("Preencha o campo Nome do Responsável", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!local) {
-      enqueueSnackbar("Preencha o campo Local", { variant: "warning" });
-      return false;
-    }
-    if (!date) {
-      enqueueSnackbar("Preencha o campo Data", { variant: "warning" });
-      return false;
-    }
+    if (!nameMinor.trim()) { setNameMinorError("Campo obrigatório."); valid = false; } else setNameMinorError("");
+    if (!nameResponsible.trim()) { setNameResponsibleError("Campo obrigatório."); valid = false; } else setNameResponsibleError("");
+    if (!responsibleAddres.trim()) { setResponsibleAddresError("Campo obrigatório."); valid = false; } else setResponsibleAddresError("");
+    if (!responsibleNumber.trim()) { setResponsibleNumberError("O telefone é obrigatório."); valid = false; }
+    else if (!validatePhone(responsibleNumber)) { setResponsibleNumberError("Telefone inválido. Use (XX) XXXXX-XXXX."); valid = false; }
+    else setResponsibleNumberError("");
 
-    return true;
+    if (!responsibleEmail.trim()) { setEmailError("O e-mail é obrigatório."); valid = false; }
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail)) { setEmailError("E-mail inválido."); valid = false; }
+    else setEmailError("");
+
+    if (!local.trim()) { setLocalError("Campo obrigatório."); valid = false; } else setLocalError("");
+
+    if (!date.trim()) { setDateError("A data é obrigatória."); valid = false; }
+    else if (!validateDate(date)) { setDateError("Data inválida. Use DD/MM/AAAA."); valid = false; }
+    else setDateError("");
+
+    return valid;
   };
 
-  async function validateForm(): Promise<DataTerm> {
+  async function validateForm(): Promise<DataTerm | undefined> {
     if (!isFormValid()) return;
 
-    const node = document.getElementById("TALEU").children;
-
-    console.log(node);
-
+    const node = document.getElementById("TALEU")!.children;
     const pdf = await generatePDF(node);
 
     const response: DataTerm = {
@@ -121,8 +104,8 @@ const Index = forwardRef((props, ref) => {
         <TaleImage src="/tale1.png" />
         <PD>
           Olá, quero te convidar para participar de um estudo chamado:
-          “Vigilância Epidemiológica em Saúde Bucal a partir da plataforma
-          web-based GestBucalSD”. Esse estudo é coordenado pelas pesquisadoras:
+          &ldquo;Vigilância Epidemiológica em Saúde Bucal a partir da plataforma
+          web-based GestBucalSD&rdquo;. Esse estudo é coordenado pelas pesquisadoras:
           Gabriela da Silveira Gaspar e Nilcema Figueiredo.
         </PD>
       </TaleContainer>
@@ -214,61 +197,104 @@ const Index = forwardRef((props, ref) => {
           receber uma cópia deste documento por email.
         </PD>
       </TaleContainer>
+
       <PD>
         Local:{" "}
-        <PDInput
-          placeholder="Local"
-          onChange={(e) => setLocal(e.target.value)}
-          value={local}
-        />
-        , Data:{" "}
-        <PDInput
-          placeholder="Local"
-          onChange={(e) => setDate(e.target.value)}
-          value={date}
-        />
+        <FieldWrap>
+          <PDInput
+            placeholder="Ex: Recife/PE"
+            value={local}
+            style={{ borderBottomColor: localError ? '#dc2626' : undefined }}
+            onChange={(e) => { setLocal(onlyLetters(e.target.value)); if (localError) setLocalError(""); }}
+          />
+          <FieldError msg={localError} />
+        </FieldWrap>
+        {" "}Data:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="DD/MM/AAAA"
+            value={date}
+            maxLength={10}
+            style={{ borderBottomColor: dateError ? '#dc2626' : undefined }}
+            onChange={(e) => {
+              const masked = maskDate(e.target.value);
+              setDate(masked);
+              if (dateError && validateDate(masked)) setDateError("");
+            }}
+            onBlur={() => {
+              if (date && !validateDate(date)) setDateError("Data inválida. Use DD/MM/AAAA.");
+            }}
+          />
+          <FieldError msg={dateError} />
+        </FieldWrap>
       </PD>
+
       <DocumentParagraphyTitle>
-        <PDInput
-          placeholder="Assinatura da criança"
-          style={{ textAlign: "center" }}
-          onChange={(e) => setNameMinor(e.target.value)}
-          value={nameMinor}
-        />
-        <br></br>
+        <FieldWrap>
+          <PDInput
+            placeholder="Assinatura da criança"
+            style={{ textAlign: "center", borderBottomColor: nameMinorError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameMinor(onlyLetters(e.target.value)); if (nameMinorError) setNameMinorError(""); }}
+            value={nameMinor}
+          />
+          <FieldError msg={nameMinorError} />
+        </FieldWrap>
+        <br />
         Assinatura da criança
       </DocumentParagraphyTitle>
+
       <DocumentParagraphyTitle>
         <b>Dados do responsável legal:</b>
       </DocumentParagraphyTitle>
+
       <DocumentParagraphyTitle>
         <PD>
-          Nome{" "}
-          <PDInput
-            value={nameResponsible}
-            onChange={(e) => setNameResponsible(e.target.value)}
-          />
+          Nome:{" "}
+          <FieldWrap>
+            <PDInput
+              value={nameResponsible}
+              style={{ borderBottomColor: nameResponsibleError ? '#dc2626' : undefined }}
+              onChange={(e) => { setNameResponsible(onlyLetters(e.target.value)); if (nameResponsibleError) setNameResponsibleError(""); }}
+            />
+            <FieldError msg={nameResponsibleError} />
+          </FieldWrap>
         </PD>
         <PD>
-          Endereço:
-          <PDInput
-            value={responsibleAddres}
-            onChange={(e) => setResponsibleAddres(e.target.value)}
-          />
+          Endereço:{" "}
+          <FieldWrap>
+            <PDInput
+              value={responsibleAddres}
+              style={{ borderBottomColor: responsibleAddresError ? '#dc2626' : undefined }}
+              onChange={(e) => { setResponsibleAddres(e.target.value); if (responsibleAddresError) setResponsibleAddresError(""); }}
+            />
+            <FieldError msg={responsibleAddresError} />
+          </FieldWrap>
         </PD>
         <PD>
-          Email:{" "}
-          <PDInput
-            value={responsibleEmail}
-            onChange={(e) => setResponsibleEmail(e.target.value)}
-          />
+          E-mail:{" "}
+          <FieldWrap>
+            <PDInput
+              value={responsibleEmail}
+              style={{ borderBottomColor: emailError ? '#dc2626' : undefined }}
+              onChange={(e) => { setResponsibleEmail(e.target.value); if (emailError) setEmailError(""); }}
+              onBlur={() => {
+                if (responsibleEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail))
+                  setEmailError("E-mail inválido.");
+              }}
+            />
+            <FieldError msg={emailError} />
+          </FieldWrap>
         </PD>
         <PD>
           Telefone:{" "}
-          <PDInput
-            value={responsibleNumber}
-            onChange={(e) => setResponsibleNumber(e.target.value)}
-          />
+          <FieldWrap>
+            <PDInput
+              value={responsibleNumber}
+              style={{ borderBottomColor: responsibleNumberError ? '#dc2626' : undefined }}
+              onChange={(e) => { setResponsibleNumber(maskPhone(e.target.value)); if (responsibleNumberError) setResponsibleNumberError(""); }}
+            />
+            <FieldError msg={responsibleNumberError} />
+          </FieldWrap>
         </PD>
       </DocumentParagraphyTitle>
     </DocumentData>

--- a/src/components/tcle/tcle-document/TALEU18.tsx
+++ b/src/components/tcle/tcle-document/TALEU18.tsx
@@ -1,91 +1,66 @@
-import {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from "react";
+import React, { forwardRef, useImperativeHandle, useState } from "react";
 import { DocumentData } from "../styled";
-import {
-  DocumentLi,
-  DocumentParagraphyTitle,
-  PD,
-  PDInput,
-  TaleImage,
-} from "./styled";
-import { generatePDF } from "../exportpdf";
-import { useSnackbar } from "notistack";
+import { DocumentLi, DocumentParagraphyTitle, PD, PDInput } from "./styled";
 import { DataTerm } from "..";
+import { generatePDF } from "../exportpdf";
+import { maskRG } from "src/core/utils/rg";
+import { maskDate, validateDate } from "src/core/utils/date";
+import { onlyLetters } from "src/core/utils/text";
+
+const FieldError = ({ msg }: { msg: string }) =>
+  msg ? <span style={{ color: '#dc2626', fontSize: '0.75em', display: 'block', marginTop: '2px', whiteSpace: 'nowrap' }}>{msg}</span> : null;
+
+const FieldWrap = ({ children }: { children: React.ReactNode }) => (
+  <span style={{ display: 'inline-flex', flexDirection: 'column', verticalAlign: 'middle' }}>
+    {children}
+  </span>
+);
 
 const Index = forwardRef((props, ref) => {
   const [nameMinor, setNameMinor] = useState<string>("");
+  const [nameMinorError, setNameMinorError] = useState<string>("");
   const [nameResearch, setNameResearch] = useState<string>("");
+  const [nameResearchError, setNameResearchError] = useState<string>("");
   const [numberMinor, setNumberMinor] = useState<string>("");
-  const [locationAndData, setLocationAndData] = useState<string>("");
+  const [numberMinorError, setNumberMinorError] = useState<string>("");
+  const [location, setLocation] = useState<string>("");
+  const [locationError, setLocationError] = useState<string>("");
+  const [date, setDate] = useState<string>("");
+  const [dateError, setDateError] = useState<string>("");
   const [nameResponsible, setNameResponsible] = useState<string>("");
+  const [nameResponsibleError, setNameResponsibleError] = useState<string>("");
   const [responsibleEmail, setResponsibleEmail] = useState<string>("");
-  const { enqueueSnackbar } = useSnackbar();
+  const [emailError, setEmailError] = useState<string>("");
 
   const isFormValid = () => {
-    if (!nameMinor) {
-      enqueueSnackbar("Preencha o campo Nome do Menor", { variant: "warning" });
-      return false;
-    }
-    if (!nameResearch) {
-      enqueueSnackbar("Preencha o campo Nome da Pesquisa", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!numberMinor) {
-      enqueueSnackbar("Preencha o campo Número do Menor", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!locationAndData) {
-      enqueueSnackbar("Preencha o campo Localização e Data", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!nameResponsible) {
-      enqueueSnackbar("Preencha o campo Nome do Responsável", {
-        variant: "warning",
-      });
-      return false;
-    }
+    let valid = true;
 
-    if (!responsibleEmail) {
-      enqueueSnackbar("Preencha o campo Email do Responsável", {
-        variant: "warning",
-      });
-      return false;
-    }
+    if (!nameMinor.trim()) { setNameMinorError("Campo obrigatório."); valid = false; } else setNameMinorError("");
+    if (!nameResearch.trim()) { setNameResearchError("Campo obrigatório."); valid = false; } else setNameResearchError("");
+    if (!nameResponsible.trim()) { setNameResponsibleError("Campo obrigatório."); valid = false; } else setNameResponsibleError("");
 
-    if (
-      !responsibleEmail ||
-      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail)
-    ) {
-      enqueueSnackbar("Preencha um e-mail válido para o Responsável", {
-        variant: "warning",
-      });
-      return false;
-    }
+    setNumberMinorError("");
 
-    return true;
+    if (!location.trim()) { setLocationError("Campo obrigatório."); valid = false; } else setLocationError("");
+
+    if (!date.trim()) { setDateError("A data é obrigatória."); valid = false; }
+    else if (!validateDate(date)) { setDateError("Data inválida. Use DD/MM/AAAA."); valid = false; }
+    else setDateError("");
+
+    if (!responsibleEmail.trim()) { setEmailError("O e-mail é obrigatório."); valid = false; }
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail)) { setEmailError("E-mail inválido."); valid = false; }
+    else setEmailError("");
+
+    return valid;
   };
 
-  async function validateForm(): Promise<DataTerm> {
+  async function validateForm(): Promise<DataTerm | undefined> {
     if (!isFormValid()) return;
 
-    const node = document.getElementById("TALE").children;
-
+    const node = document.getElementById("TALE")!.children;
     const pdf = await generatePDF(node);
 
-    console.log(pdf);
-
-    const response: DataTerm = {
+    return {
       valid: true,
       type: "TALE",
       email: responsibleEmail,
@@ -93,14 +68,10 @@ const Index = forwardRef((props, ref) => {
       pdf: await pdf,
       created_at: new Date(),
     };
-    return response;
   }
 
   useImperativeHandle(ref, () => ({
-    getStates: async () => {
-      const response = validateForm();
-      return response;
-    },
+    getStates: async () => validateForm(),
   }));
 
   return (
@@ -114,12 +85,16 @@ const Index = forwardRef((props, ref) => {
       </DocumentParagraphyTitle>
       <PD>
         Convidamos você{" "}
-        <PDInput
-          placeholder="Nome do menor"
-          onChange={(e) => setNameMinor(e.target.value)}
-          value={nameMinor}
-        />
-        , após autorização dos seus pais ou dos responsáveis legais, para
+        <FieldWrap>
+          <PDInput
+            placeholder="Nome do menor"
+            value={nameMinor}
+            style={{ borderBottomColor: nameMinorError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameMinor(onlyLetters(e.target.value)); if (nameMinorError) setNameMinorError(""); }}
+          />
+          <FieldError msg={nameMinorError} />
+        </FieldWrap>
+        {" "}, após autorização dos seus pais ou dos responsáveis legais, para
         participar como voluntário (a) da pesquisa: Vigilância Epidemiológica em
         Saúde Bucal a partir da plataforma web-based GestBucalSD, que tem como
         objetivo investigar a saúde bucal e a satisfação com serviços
@@ -132,7 +107,6 @@ const Index = forwardRef((props, ref) => {
         Engenharia, S/N- Bloco D – 1º andar, Cidade Universitária – Recife/PE -
         CEP 50.740-600.
       </PD>
-
       <PD>
         Informamos que seu pai/mãe ou responsável legal permitiu a sua
         participação na pesquisa, mas que você estará livre para decidir
@@ -157,7 +131,7 @@ const Index = forwardRef((props, ref) => {
       </DocumentParagraphyTitle>
       <ul>
         <DocumentLi>
-          <b>Descrição da pesquisa e esclarecimento da participação:</b>Para se
+          <b>Descrição da pesquisa e esclarecimento da participação:</b> Para se
           conhecer a realidade da saúde bucal dos participantes e a satisfação
           com serviços odontológicos, vamos precisar que participe de entrevista
           com questões sobre aspectos socioeconômicos, grau de escolaridade,
@@ -174,7 +148,7 @@ const Index = forwardRef((props, ref) => {
           GestBucalSD.
         </DocumentLi>
         <DocumentLi>
-          <b>RISCOS:</b>Esse estudo tem riscos mínimos. Sobre a entrevista, o
+          <b>RISCOS:</b> Esse estudo tem riscos mínimos. Sobre a entrevista, o
           participante pode considerar alguma pergunta estranha ou que gere
           constrangimento. Pode ainda considerar como risco o manejo e proteção
           dos seus dados. Caso haja incômodo à entrevista, você deve falar com o
@@ -193,7 +167,7 @@ const Index = forwardRef((props, ref) => {
           examinador sobre o incômodo e ele dará solução.
         </DocumentLi>
         <DocumentLi>
-          <b>BENEFÍCIOS diretos/indiretos para os voluntários:</b>Benefícios
+          <b>BENEFÍCIOS diretos/indiretos para os voluntários:</b> Benefícios
           diretos: Com o conhecimento da realidade de saúde bucal e dos serviços
           odontológicos haverá organização do atendimento em função das
           necessidades e prioridade locais para a melhoria da qualidade do
@@ -235,36 +209,50 @@ const Index = forwardRef((props, ref) => {
       </PD>
 
       <DocumentParagraphyTitle>
-        <PDInput
-          onChange={(e) => setNameResearch(e.target.value)}
-          value={nameResearch}
-          placeholder="Assinatura do pesquisador"
-          style={{ textAlign: "center" }}
-        />
-        <br></br>
+        <FieldWrap>
+          <PDInput
+            placeholder="Assinatura do pesquisador"
+            style={{ textAlign: "center", borderBottomColor: nameResearchError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameResearch(onlyLetters(e.target.value)); if (nameResearchError) setNameResearchError(""); }}
+            value={nameResearch}
+          />
+          <FieldError msg={nameResearchError} />
+        </FieldWrap>
+        <br />
         Assinatura do pesquisador
       </DocumentParagraphyTitle>
 
       <DocumentParagraphyTitle>
-        <b>
-          ASSENTIMENTO DO(DA) MENOR DE IDADE EM PARTICIPAR COMO VOLUNTÁRIO(A)
-        </b>
+        <b>ASSENTIMENTO DO(DA) MENOR DE IDADE EM PARTICIPAR COMO VOLUNTÁRIO(A)</b>
       </DocumentParagraphyTitle>
 
       <PD>
         Eu,{" "}
-        <PDInput
-          value={nameMinor}
-          onChange={(e) => setNameMinor(e.target.value)}
-          placeholder="Nome do menor"
-        />
-        , portador (a) do documento de Identidade
-        <PDInput
-          value={numberMinor}
-          onChange={(e) => setNumberMinor(e.target.value)}
-          placeholder="CPF do menor"
-        />
-        , (se já tiver documento), abaixo assinado, concordo em participar do
+        <FieldWrap>
+          <PDInput
+            placeholder="Nome do menor"
+            value={nameMinor}
+            style={{ borderBottomColor: nameMinorError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameMinor(onlyLetters(e.target.value)); if (nameMinorError) setNameMinorError(""); }}
+          />
+          <FieldError msg={nameMinorError} />
+        </FieldWrap>
+        {" "}, portador (a) do documento de Identidade{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="00.000.000-0"
+            value={numberMinor}
+            maxLength={12}
+            style={{ borderBottomColor: numberMinorError ? '#dc2626' : undefined }}
+            onChange={(e) => {
+              const masked = maskRG(e.target.value);
+              setNumberMinor(masked);
+              if (numberMinorError) setNumberMinorError("");
+            }}
+          />
+          <FieldError msg={numberMinorError} />
+        </FieldWrap>
+        {" "}, (se já tiver documento), abaixo assinado, concordo em participar do
         estudo Vigilância Epidemiológica em Saúde Bucal a partir da plataforma
         web-based GestBucalSD, como voluntário (a). Fui informado (a) e
         esclarecido (a) pelo (a) pesquisador (a) sobre a pesquisa, o que vai ser
@@ -272,26 +260,60 @@ const Index = forwardRef((props, ref) => {
         com a minha participação. Foi-me garantido que posso desistir de
         participar a qualquer momento, sem que eu ou meus pais precisem pagar
         nada.
-        <br />
-        Local e data:{" "}
+      </PD>
+      <PD>
+        Local:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="Ex: Recife/PE"
+            value={location}
+            style={{ borderBottomColor: locationError ? '#dc2626' : undefined }}
+            onChange={(e) => { setLocation(onlyLetters(e.target.value)); if (locationError) setLocationError(""); }}
+          />
+          <FieldError msg={locationError} />
+        </FieldWrap>
+        {" "}Data:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="DD/MM/AAAA"
+            value={date}
+            maxLength={10}
+            style={{ borderBottomColor: dateError ? '#dc2626' : undefined }}
+            onChange={(e) => {
+              const masked = maskDate(e.target.value);
+              setDate(masked);
+              if (dateError && validateDate(masked)) setDateError("");
+            }}
+            onBlur={() => {
+              if (date && !validateDate(date)) setDateError("Data inválida. Use DD/MM/AAAA.");
+            }}
+          />
+          <FieldError msg={dateError} />
+        </FieldWrap>
+      </PD>
+      <PD>
+        Assinatura do (da) responsável:{" "}
         <PDInput
-          value={locationAndData}
-          onChange={(e) => setLocationAndData(e.target.value)}
-          placeholder="Local e data"
-        />
-        ,<br />
-        Assinatura do (da) responsável:
-        <PDInput
+          placeholder="Assinatura do responsável"
           value={nameResponsible}
-          onChange={(e) => setNameResponsible(e.target.value)}
-          placeholder="Assinatura do responsavel"
+          onChange={(e) => setNameResponsible(onlyLetters(e.target.value))}
         />
-        , Email:{" "}
-        <PDInput
-          placeholder="Email"
-          value={responsibleEmail}
-          onChange={(e) => setResponsibleEmail(e.target.value)}
-        />
+      </PD>
+      <PD>
+        E-mail:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="email@exemplo.com"
+            value={responsibleEmail}
+            style={{ borderBottomColor: emailError ? '#dc2626' : undefined }}
+            onChange={(e) => { setResponsibleEmail(e.target.value); if (emailError) setEmailError(""); }}
+            onBlur={() => {
+              if (responsibleEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail))
+                setEmailError("E-mail inválido.");
+            }}
+          />
+          <FieldError msg={emailError} />
+        </FieldWrap>
       </PD>
     </DocumentData>
   );

--- a/src/components/tcle/tcle-document/TCLE.tsx
+++ b/src/components/tcle/tcle-document/TCLE.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   Dispatch,
   forwardRef,
   SetStateAction,
@@ -15,76 +15,66 @@ import {
   PDInput,
   TaleImage,
 } from "./styled";
-import { useSnackbar } from "notistack";
 import { DataTerm, PropsTerm } from "..";
 import { generatePDF } from "../exportpdf";
+import { maskCPF, validateCPF } from "src/core/utils/cpf";
+import { maskDate, validateDate } from "src/core/utils/date";
+import { onlyLetters } from "src/core/utils/text";
+
+const FieldError = ({ msg }: { msg: string }) =>
+  msg ? <span style={{ color: '#dc2626', fontSize: '0.75em', display: 'block', marginTop: '2px', whiteSpace: 'nowrap' }}>{msg}</span> : null;
+
+const FieldWrap = ({ children }: { children: React.ReactNode }) => (
+  <span style={{ display: 'inline-flex', flexDirection: 'column', verticalAlign: 'middle' }}>
+    {children}
+  </span>
+);
 
 const Index = forwardRef((props, ref) => {
   const [nameMinor, setNameMinor] = useState<string>("");
+  const [nameMinorError, setNameMinorError] = useState<string>("");
   const [nameResearch, setNameResearch] = useState<string>("");
+  const [nameResearchError, setNameResearchError] = useState<string>("");
   const [responsibleCPF, setResponsibleCPF] = useState<string>("");
-  const [locationAndData, setLocationAndData] = useState<string>("");
+  const [cpfError, setCpfError] = useState<string>("");
+  const [location, setLocation] = useState<string>("");
+  const [locationError, setLocationError] = useState<string>("");
+  const [date, setDate] = useState<string>("");
+  const [dateError, setDateError] = useState<string>("");
   const [nameResponsible, setNameResponsible] = useState<string>("");
+  const [nameResponsibleError, setNameResponsibleError] = useState<string>("");
   const [responsibleEmail, setResponsibleEmail] = useState<string>("");
-  const { enqueueSnackbar } = useSnackbar();
+  const [emailError, setEmailError] = useState<string>("");
 
   const isFormValid = () => {
-    if (!nameMinor.trim()) {
-      enqueueSnackbar("O campo Nome do menor está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
+    let valid = true;
 
-    if (!nameResearch.trim()) {
-      enqueueSnackbar("O campo Nome do pesquisador está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!responsibleCPF.trim()) {
-      enqueueSnackbar("O campo CPF do responsável está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!locationAndData.trim()) {
-      enqueueSnackbar("O campo Local e Data está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!nameResponsible.trim()) {
-      enqueueSnackbar("O campo Nome do responsável está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
+    if (!nameMinor.trim()) { setNameMinorError("Campo obrigatório."); valid = false; } else setNameMinorError("");
+    if (!nameResearch.trim()) { setNameResearchError("Campo obrigatório."); valid = false; } else setNameResearchError("");
 
-    if (!responsibleEmail) {
-      enqueueSnackbar("Preencha o campo Email do Responsável", {
-        variant: "warning",
-      });
-      return false;
-    }
+    if (!responsibleCPF.trim()) { setCpfError("O CPF é obrigatório."); valid = false; }
+    else if (!validateCPF(responsibleCPF)) { setCpfError("CPF inválido. Verifique os dígitos."); valid = false; }
+    else setCpfError("");
 
-    if (
-      !responsibleEmail ||
-      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail)
-    ) {
-      enqueueSnackbar("Preencha um e-mail válido para o Responsável", {
-        variant: "warning",
-      });
-      return false;
-    }
+    if (!location.trim()) { setLocationError("Campo obrigatório."); valid = false; } else setLocationError("");
 
-    return true;
+    if (!date.trim()) { setDateError("A data é obrigatória."); valid = false; }
+    else if (!validateDate(date)) { setDateError("Data inválida. Use DD/MM/AAAA."); valid = false; }
+    else setDateError("");
+
+    if (!nameResponsible.trim()) { setNameResponsibleError("Campo obrigatório."); valid = false; } else setNameResponsibleError("");
+
+    if (!responsibleEmail.trim()) { setEmailError("O e-mail é obrigatório."); valid = false; }
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail)) { setEmailError("E-mail inválido."); valid = false; }
+    else setEmailError("");
+
+    return valid;
   };
 
-  async function validateForm(): Promise<DataTerm> {
+  async function validateForm(): Promise<DataTerm | undefined> {
     if (!isFormValid()) return;
 
-    const node = document.getElementById("TCLE").children;
+    const node = document.getElementById("TCLE")!.children;
 
     const pdf = await generatePDF(node);
 
@@ -113,7 +103,7 @@ const Index = forwardRef((props, ref) => {
         Convidamos você{" "}
         <PDInput
           placeholder="Nome do menor"
-          onChange={(e) => setNameMinor(e.target.value)}
+          onChange={(e) => setNameMinor(onlyLetters(e.target.value))}
           value={nameMinor}
         />
         , após autorização dos seus pais ou dos responsáveis legais, para
@@ -141,7 +131,7 @@ const Index = forwardRef((props, ref) => {
         Solicitamos a sua autorização para convidar o (a) seu/sua filho (a){" "}
         <PDInput
           placeholder="Nome do menor"
-          onChange={(e) => setNameMinor(e.target.value)}
+          onChange={(e) => setNameMinor(onlyLetters(e.target.value))}
           value={nameMinor}
         />
         , ou menor que está sob sua responsabilidade para participar, como
@@ -256,13 +246,16 @@ const Index = forwardRef((props, ref) => {
       </PD>
 
       <DocumentParagraphyTitle>
-        <PDInput
-          placeholder="Assinatura do pesquisador"
-          style={{ textAlign: "center" }}
-          onChange={(e) => setNameResearch(e.target.value)}
-          value={nameResearch}
-        />
-        <br></br>
+        <FieldWrap>
+          <PDInput
+            placeholder="Assinatura do pesquisador"
+            style={{ textAlign: "center", borderBottomColor: nameResearchError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameResearch(onlyLetters(e.target.value)); if (nameResearchError) setNameResearchError(""); }}
+            value={nameResearch}
+          />
+          <FieldError msg={nameResearchError} />
+        </FieldWrap>
+        <br />
         Assinatura do pesquisador
       </DocumentParagraphyTitle>
 
@@ -272,24 +265,45 @@ const Index = forwardRef((props, ref) => {
 
       <PD>
         Eu,{" "}
-        <PDInput
-          placeholder="Nome do responsavel"
-          value={nameResponsible}
-          onChange={(e) => setNameResponsible(e.target.value)}
-        />
-        , CPF{" "}
-        <PDInput
-          placeholder="CPF do responsavel"
-          value={responsibleCPF}
-          onChange={(e) => setResponsibleCPF(e.target.value)}
-        />
-        , abaixo assinado, responsável por{" "}
-        <PDInput
-          placeholder="Nome do menor"
-          onChange={(e) => setNameMinor(e.target.value)}
-          value={nameMinor}
-        />
-        , autorizo a sua participação no estudo Vigilância Epidermiológica em
+        <FieldWrap>
+          <PDInput
+            placeholder="Nome do responsável"
+            value={nameResponsible}
+            style={{ borderBottomColor: nameResponsibleError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameResponsible(onlyLetters(e.target.value)); if (nameResponsibleError) setNameResponsibleError(""); }}
+          />
+          <FieldError msg={nameResponsibleError} />
+        </FieldWrap>
+        {" "}, CPF{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="000.000.000-00"
+            value={responsibleCPF}
+            maxLength={14}
+            style={{ borderBottomColor: cpfError ? '#dc2626' : undefined }}
+            onChange={(e) => {
+              const masked = maskCPF(e.target.value);
+              setResponsibleCPF(masked);
+              if (cpfError && validateCPF(masked)) setCpfError("");
+            }}
+            onBlur={() => {
+              if (responsibleCPF && !validateCPF(responsibleCPF))
+                setCpfError("CPF inválido. Verifique os dígitos.");
+            }}
+          />
+          <FieldError msg={cpfError} />
+        </FieldWrap>
+        {" "}, abaixo assinado, responsável por{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="Nome do menor"
+            style={{ borderBottomColor: nameMinorError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameMinor(onlyLetters(e.target.value)); if (nameMinorError) setNameMinorError(""); }}
+            value={nameMinor}
+          />
+          <FieldError msg={nameMinorError} />
+        </FieldWrap>
+        {" "}, autorizo a sua participação no estudo Vigilância Epidermiológica em
         Saúde Bucal a partir da plataforma web-based GestBucalSD, como
         voluntário(a). Fui devidamente informado (a) e esclarecido (a) pelo (a)
         pesquisador (a) sobre a pesquisa, os procedimentos nela envolvidos,
@@ -297,24 +311,61 @@ const Index = forwardRef((props, ref) => {
         dele (a). Foi-me garantido que posso retirar o meu consentimento a
         qualquer momento, sem que isto leve a qualquer penalidade ou interrupção
         de seu acompanhamento/ assistência/tratamento para mim ou para o (a)
-        menor em questão. Local e data
+        menor em questão.
+      </PD>
+      <PD>
+        Local:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="Ex: Recife/PE"
+            value={location}
+            style={{ borderBottomColor: locationError ? '#dc2626' : undefined }}
+            onChange={(e) => { setLocation(onlyLetters(e.target.value)); if (locationError) setLocationError(""); }}
+          />
+          <FieldError msg={locationError} />
+        </FieldWrap>
+        {" "}Data:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="DD/MM/AAAA"
+            value={date}
+            maxLength={10}
+            style={{ borderBottomColor: dateError ? '#dc2626' : undefined }}
+            onChange={(e) => {
+              const masked = maskDate(e.target.value);
+              setDate(masked);
+              if (dateError && validateDate(masked)) setDateError("");
+            }}
+            onBlur={() => {
+              if (date && !validateDate(date)) setDateError("Data inválida. Use DD/MM/AAAA.");
+            }}
+          />
+          <FieldError msg={dateError} />
+        </FieldWrap>
+      </PD>
+      <PD>
+        Assinatura do (da) responsável:{" "}
         <PDInput
-          placeholder="Local e data"
-          value={locationAndData}
-          onChange={(e) => setLocationAndData(e.target.value)}
-        />
-        , Assinatura do (da) responsável:
-        <PDInput
-          placeholder="Assinatura do responsavel"
+          placeholder="Assinatura do responsável"
           value={nameResponsible}
-          onChange={(e) => setNameResponsible(e.target.value)}
+          onChange={(e) => setNameResponsible(onlyLetters(e.target.value))}
         />
-        , Email:{" "}
-        <PDInput
-          placeholder="Email"
-          value={responsibleEmail}
-          onChange={(e) => setResponsibleEmail(e.target.value)}
-        />
+      </PD>
+      <PD>
+        E-mail:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="email@exemplo.com"
+            value={responsibleEmail}
+            style={{ borderBottomColor: emailError ? '#dc2626' : undefined }}
+            onChange={(e) => { setResponsibleEmail(e.target.value); if (emailError) setEmailError(""); }}
+            onBlur={() => {
+              if (responsibleEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail))
+                setEmailError("E-mail inválido.");
+            }}
+          />
+          <FieldError msg={emailError} />
+        </FieldWrap>
       </PD>
     </DocumentData>
   );

--- a/src/components/tcle/tcle-document/TCLE2.tsx
+++ b/src/components/tcle/tcle-document/TCLE2.tsx
@@ -1,86 +1,65 @@
-import {
-  Dispatch,
-  forwardRef,
-  SetStateAction,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from "react";
+import React, { forwardRef, useImperativeHandle, useState } from "react";
 import { DocumentData } from "../styled";
-import {
-  DocumentLi,
-  DocumentParagraphyTitle,
-  PD,
-  PDInput,
-  TaleImage,
-} from "./styled";
-import { useSnackbar } from "notistack";
-import { DataTerm, PropsTerm } from "..";
+import { DocumentLi, DocumentParagraphyTitle, PD, PDInput } from "./styled";
+import { DataTerm } from "..";
 import { generatePDF } from "../exportpdf";
+import { maskCPF, validateCPF } from "src/core/utils/cpf";
+import { maskDate, validateDate } from "src/core/utils/date";
+import { onlyLetters } from "src/core/utils/text";
+
+const FieldError = ({ msg }: { msg: string }) =>
+  msg ? <span style={{ color: '#dc2626', fontSize: '0.75em', display: 'block', marginTop: '2px', whiteSpace: 'nowrap' }}>{msg}</span> : null;
+
+const FieldWrap = ({ children }: { children: React.ReactNode }) => (
+  <span style={{ display: 'inline-flex', flexDirection: 'column', verticalAlign: 'middle' }}>
+    {children}
+  </span>
+);
 
 const Index = forwardRef((props, ref) => {
   const [nameResearch, setNameResearch] = useState<string>("");
+  const [nameResearchError, setNameResearchError] = useState<string>("");
   const [responsibleCPF, setResponsibleCPF] = useState<string>("");
-  const [locationAndData, setLocationAndData] = useState<string>("");
+  const [cpfError, setCpfError] = useState<string>("");
+  const [location, setLocation] = useState<string>("");
+  const [locationError, setLocationError] = useState<string>("");
+  const [date, setDate] = useState<string>("");
+  const [dateError, setDateError] = useState<string>("");
   const [nameResponsible, setNameResponsible] = useState<string>("");
+  const [nameResponsibleError, setNameResponsibleError] = useState<string>("");
   const [responsibleEmail, setResponsibleEmail] = useState<string>("");
-  const { enqueueSnackbar } = useSnackbar();
+  const [emailError, setEmailError] = useState<string>("");
 
   const isFormValid = () => {
-    if (!nameResearch.trim()) {
-      enqueueSnackbar("O campo Nome do pesquisador está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!responsibleCPF.trim()) {
-      enqueueSnackbar("O campo CPF do participante está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!locationAndData.trim()) {
-      enqueueSnackbar("O campo Local e Data está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!nameResponsible.trim()) {
-      enqueueSnackbar("O campo Nome do participante está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
+    let valid = true;
 
-    if (!responsibleEmail) {
-      enqueueSnackbar("Preencha o campo Email do participante", {
-        variant: "warning",
-      });
-      return false;
-    }
+    if (!nameResearch.trim()) { setNameResearchError("Campo obrigatório."); valid = false; } else setNameResearchError("");
+    if (!nameResponsible.trim()) { setNameResponsibleError("Campo obrigatório."); valid = false; } else setNameResponsibleError("");
 
-    if (
-      !responsibleEmail ||
-      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail)
-    ) {
-      enqueueSnackbar("Preencha um e-mail válido para o participante", {
-        variant: "warning",
-      });
-      return false;
-    }
+    if (!responsibleCPF.trim()) { setCpfError("O CPF é obrigatório."); valid = false; }
+    else if (!validateCPF(responsibleCPF)) { setCpfError("CPF inválido. Verifique os dígitos."); valid = false; }
+    else setCpfError("");
 
-    return true;
+    if (!location.trim()) { setLocationError("Campo obrigatório."); valid = false; } else setLocationError("");
+
+    if (!date.trim()) { setDateError("A data é obrigatória."); valid = false; }
+    else if (!validateDate(date)) { setDateError("Data inválida. Use DD/MM/AAAA."); valid = false; }
+    else setDateError("");
+
+    if (!responsibleEmail.trim()) { setEmailError("O e-mail é obrigatório."); valid = false; }
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail)) { setEmailError("E-mail inválido."); valid = false; }
+    else setEmailError("");
+
+    return valid;
   };
 
-  async function validateForm(): Promise<DataTerm> {
+  async function validateForm(): Promise<DataTerm | undefined> {
     if (!isFormValid()) return;
 
-    const node = document.getElementById("TCLE").children;
-
+    const node = document.getElementById("TCLE2")!.children;
     const pdf = await generatePDF(node);
 
-    const response: DataTerm = {
+    return {
       valid: true,
       type: "TCLE",
       email: responsibleEmail,
@@ -88,19 +67,14 @@ const Index = forwardRef((props, ref) => {
       pdf: await pdf,
       created_at: new Date(),
     };
-
-    return response;
   }
 
   useImperativeHandle(ref, () => ({
-    getStates: async () => {
-      const response = validateForm();
-      return response;
-    },
+    getStates: async () => validateForm(),
   }));
 
   return (
-    <DocumentData id="TCLE">
+    <DocumentData id="TCLE2">
       <DocumentParagraphyTitle>
         <b>UNIVERSIDADE FEDERAL DE PERNAMBUCO</b>
       </DocumentParagraphyTitle>
@@ -220,13 +194,16 @@ const Index = forwardRef((props, ref) => {
       </PD>
 
       <DocumentParagraphyTitle>
-        <PDInput
-          placeholder="Assinatura do pesquisador"
-          style={{ textAlign: "center" }}
-          onChange={(e) => setNameResearch(e.target.value)}
-          value={nameResearch}
-        />
-        <br></br>
+        <FieldWrap>
+          <PDInput
+            placeholder="Assinatura do pesquisador"
+            style={{ textAlign: "center", borderBottomColor: nameResearchError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameResearch(onlyLetters(e.target.value)); if (nameResearchError) setNameResearchError(""); }}
+            value={nameResearch}
+          />
+          <FieldError msg={nameResearchError} />
+        </FieldWrap>
+        <br />
         Assinatura do pesquisador
       </DocumentParagraphyTitle>
 
@@ -236,18 +213,35 @@ const Index = forwardRef((props, ref) => {
 
       <PD>
         Eu,{" "}
-        <PDInput
-          placeholder="Nome do participante"
-          value={nameResponsible}
-          onChange={(e) => setNameResponsible(e.target.value)}
-        />
-        , CPF{" "}
-        <PDInput
-          placeholder="CPF do participante"
-          value={responsibleCPF}
-          onChange={(e) => setResponsibleCPF(e.target.value)}
-        />
-        , abaixo assinado, após a leitura (ou a escuta da leitura) deste
+        <FieldWrap>
+          <PDInput
+            placeholder="Nome do participante"
+            value={nameResponsible}
+            style={{ borderBottomColor: nameResponsibleError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameResponsible(onlyLetters(e.target.value)); if (nameResponsibleError) setNameResponsibleError(""); }}
+          />
+          <FieldError msg={nameResponsibleError} />
+        </FieldWrap>
+        {" "}, CPF{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="000.000.000-00"
+            value={responsibleCPF}
+            maxLength={14}
+            style={{ borderBottomColor: cpfError ? '#dc2626' : undefined }}
+            onChange={(e) => {
+              const masked = maskCPF(e.target.value);
+              setResponsibleCPF(masked);
+              if (cpfError && validateCPF(masked)) setCpfError("");
+            }}
+            onBlur={() => {
+              if (responsibleCPF && !validateCPF(responsibleCPF))
+                setCpfError("CPF inválido. Verifique os dígitos.");
+            }}
+          />
+          <FieldError msg={cpfError} />
+        </FieldWrap>
+        {" "}, abaixo assinado, após a leitura (ou a escuta da leitura) deste
         documento e de ter tido a oportunidade de conversar e ter esclarecido as
         minhas dúvidas com o pesquisador responsável, concordo em participar do
         estudo Vigilância Epidermiológica em Saúde Bucal a partir da plataforma
@@ -258,28 +252,65 @@ const Index = forwardRef((props, ref) => {
         retirar o meu consentimento a qualquer momento, sem que isto leve a
         qualquer penalidade ou interrupção de meu acompanhamento/
         assistência/tratamento.
-        <PDInput
-          placeholder="Local e data"
-          value={locationAndData}
-          onChange={(e) => setLocationAndData(e.target.value)}
-        />
-        , Assinatura do (da) responsável:
+      </PD>
+      <PD>
+        Local:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="Ex: Recife/PE"
+            value={location}
+            style={{ borderBottomColor: locationError ? '#dc2626' : undefined }}
+            onChange={(e) => { setLocation(onlyLetters(e.target.value)); if (locationError) setLocationError(""); }}
+          />
+          <FieldError msg={locationError} />
+        </FieldWrap>
+        {" "}Data:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="DD/MM/AAAA"
+            value={date}
+            maxLength={10}
+            style={{ borderBottomColor: dateError ? '#dc2626' : undefined }}
+            onChange={(e) => {
+              const masked = maskDate(e.target.value);
+              setDate(masked);
+              if (dateError && validateDate(masked)) setDateError("");
+            }}
+            onBlur={() => {
+              if (date && !validateDate(date)) setDateError("Data inválida. Use DD/MM/AAAA.");
+            }}
+          />
+          <FieldError msg={dateError} />
+        </FieldWrap>
+      </PD>
+      <PD>
+        Assinatura do (da) participante:{" "}
         <PDInput
           placeholder="Assinatura do participante"
           value={nameResponsible}
-          onChange={(e) => setNameResponsible(e.target.value)}
+          onChange={(e) => setNameResponsible(onlyLetters(e.target.value))}
         />
-        , Email:{" "}
-        <PDInput
-          placeholder="Email"
-          value={responsibleEmail}
-          onChange={(e) => setResponsibleEmail(e.target.value)}
-        />
+      </PD>
+      <PD>
+        E-mail:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="email@exemplo.com"
+            value={responsibleEmail}
+            style={{ borderBottomColor: emailError ? '#dc2626' : undefined }}
+            onChange={(e) => { setResponsibleEmail(e.target.value); if (emailError) setEmailError(""); }}
+            onBlur={() => {
+              if (responsibleEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail))
+                setEmailError("E-mail inválido.");
+            }}
+          />
+          <FieldError msg={emailError} />
+        </FieldWrap>
       </PD>
     </DocumentData>
   );
 });
 
-Index.displayName = "TCLE";
+Index.displayName = "TCLE2";
 
 export default Index;

--- a/src/components/tcle/tcle-document/TCLEPROF.tsx
+++ b/src/components/tcle/tcle-document/TCLEPROF.tsx
@@ -1,79 +1,54 @@
-import {
-  Dispatch,
-  forwardRef,
-  SetStateAction,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from "react";
+import React, { forwardRef, useImperativeHandle, useState } from "react";
 import { DocumentData } from "../styled";
-import {
-  DocumentLi,
-  DocumentParagraphyTitle,
-  PD,
-  PDInput,
-  TaleImage,
-} from "./styled";
-import { useSnackbar } from "notistack";
-import { DataTerm, PropsTerm } from "..";
+import { DocumentLi, DocumentParagraphyTitle, PD, PDInput } from "./styled";
+import { DataTerm } from "..";
 import { generatePDF } from "../exportpdf";
+import { maskCPF, validateCPF } from "src/core/utils/cpf";
+import { onlyLetters } from "src/core/utils/text";
+
+const FieldError = ({ msg }: { msg: string }) =>
+  msg ? <span style={{ color: '#dc2626', fontSize: '0.75em', display: 'block', marginTop: '2px', whiteSpace: 'nowrap' }}>{msg}</span> : null;
+
+const FieldWrap = ({ children }: { children: React.ReactNode }) => (
+  <span style={{ display: 'inline-flex', flexDirection: 'column', verticalAlign: 'middle' }}>
+    {children}
+  </span>
+);
 
 const Index = forwardRef((props, ref) => {
   const [nameResearch, setNameResearch] = useState<string>("");
+  const [nameResearchError, setNameResearchError] = useState<string>("");
   const [responsibleCPF, setResponsibleCPF] = useState<string>("");
+  const [cpfError, setCpfError] = useState<string>("");
   const [nameResponsible, setNameResponsible] = useState<string>("");
+  const [nameResponsibleError, setNameResponsibleError] = useState<string>("");
   const [responsibleEmail, setResponsibleEmail] = useState<string>("");
-  const { enqueueSnackbar } = useSnackbar();
+  const [emailError, setEmailError] = useState<string>("");
 
   const isFormValid = () => {
-    if (!nameResearch.trim()) {
-      enqueueSnackbar("O campo Nome do pesquisador está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!responsibleCPF.trim()) {
-      enqueueSnackbar("O campo CPF do participante está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
-    if (!nameResponsible.trim()) {
-      enqueueSnackbar("O campo Nome do participante está vazio.", {
-        variant: "warning",
-      });
-      return false;
-    }
+    let valid = true;
 
-    if (!responsibleEmail) {
-      enqueueSnackbar("Preencha o campo Email do participante", {
-        variant: "warning",
-      });
-      return false;
-    }
+    if (!nameResearch.trim()) { setNameResearchError("Campo obrigatório."); valid = false; } else setNameResearchError("");
+    if (!nameResponsible.trim()) { setNameResponsibleError("Campo obrigatório."); valid = false; } else setNameResponsibleError("");
 
-    if (
-      !responsibleEmail ||
-      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail)
-    ) {
-      enqueueSnackbar("Preencha um e-mail válido para o participante", {
-        variant: "warning",
-      });
-      return false;
-    }
+    if (!responsibleCPF.trim()) { setCpfError("O CPF é obrigatório."); valid = false; }
+    else if (!validateCPF(responsibleCPF)) { setCpfError("CPF inválido. Verifique os dígitos."); valid = false; }
+    else setCpfError("");
 
-    return true;
+    if (!responsibleEmail.trim()) { setEmailError("O e-mail é obrigatório."); valid = false; }
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail)) { setEmailError("E-mail inválido."); valid = false; }
+    else setEmailError("");
+
+    return valid;
   };
 
-  async function validateForm(): Promise<DataTerm> {
+  async function validateForm(): Promise<DataTerm | undefined> {
     if (!isFormValid()) return;
 
-    const node = document.getElementById("TCLE").children;
-
+    const node = document.getElementById("TCLEPROF")!.children;
     const pdf = await generatePDF(node);
 
-    const response: DataTerm = {
+    return {
       valid: true,
       type: "TCLE",
       email: responsibleEmail,
@@ -81,19 +56,14 @@ const Index = forwardRef((props, ref) => {
       pdf: await pdf,
       created_at: new Date(),
     };
-
-    return response;
   }
 
   useImperativeHandle(ref, () => ({
-    getStates: async () => {
-      const response = validateForm();
-      return response;
-    },
+    getStates: async () => validateForm(),
   }));
 
   return (
-    <DocumentData id="TCLE">
+    <DocumentData id="TCLEPROF">
       <DocumentParagraphyTitle>
         <b>UNIVERSIDADE FEDERAL DE PERNAMBUCO</b>
       </DocumentParagraphyTitle>
@@ -172,7 +142,7 @@ const Index = forwardRef((props, ref) => {
           tomada de decisão para mudanças locais com vistas à melhoria da
           qualidade, resultando em serviços mais efetivos, promotores de saúde.
           E, o uso de ferramenta eletrônica oportuniza decisão ágil para
-          governança inteligente
+          governança inteligente.
         </DocumentLi>
       </ul>
       <PD>
@@ -204,13 +174,16 @@ const Index = forwardRef((props, ref) => {
       </PD>
 
       <DocumentParagraphyTitle>
-        <PDInput
-          placeholder="Assinatura do pesquisador"
-          style={{ textAlign: "center" }}
-          onChange={(e) => setNameResearch(e.target.value)}
-          value={nameResearch}
-        />
-        <br></br>
+        <FieldWrap>
+          <PDInput
+            placeholder="Assinatura do pesquisador"
+            style={{ textAlign: "center", borderBottomColor: nameResearchError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameResearch(onlyLetters(e.target.value)); if (nameResearchError) setNameResearchError(""); }}
+            value={nameResearch}
+          />
+          <FieldError msg={nameResearchError} />
+        </FieldWrap>
+        <br />
         Assinatura do pesquisador
       </DocumentParagraphyTitle>
 
@@ -220,18 +193,35 @@ const Index = forwardRef((props, ref) => {
 
       <PD>
         Eu,{" "}
-        <PDInput
-          placeholder="Nome do participante"
-          value={nameResponsible}
-          onChange={(e) => setNameResponsible(e.target.value)}
-        />
-        , CPF{" "}
-        <PDInput
-          placeholder="CPF do participante"
-          value={responsibleCPF}
-          onChange={(e) => setResponsibleCPF(e.target.value)}
-        />
-        , abaixo assinado, após a leitura (ou a escuta da leitura) deste
+        <FieldWrap>
+          <PDInput
+            placeholder="Nome do participante"
+            value={nameResponsible}
+            style={{ borderBottomColor: nameResponsibleError ? '#dc2626' : undefined }}
+            onChange={(e) => { setNameResponsible(onlyLetters(e.target.value)); if (nameResponsibleError) setNameResponsibleError(""); }}
+          />
+          <FieldError msg={nameResponsibleError} />
+        </FieldWrap>
+        {" "}, CPF{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="000.000.000-00"
+            value={responsibleCPF}
+            maxLength={14}
+            style={{ borderBottomColor: cpfError ? '#dc2626' : undefined }}
+            onChange={(e) => {
+              const masked = maskCPF(e.target.value);
+              setResponsibleCPF(masked);
+              if (cpfError && validateCPF(masked)) setCpfError("");
+            }}
+            onBlur={() => {
+              if (responsibleCPF && !validateCPF(responsibleCPF))
+                setCpfError("CPF inválido. Verifique os dígitos.");
+            }}
+          />
+          <FieldError msg={cpfError} />
+        </FieldWrap>
+        {" "}, abaixo assinado, após a leitura (ou a escuta da leitura) deste
         documento e de ter tido a oportunidade de conversar e ter esclarecido as
         minhas dúvidas com o pesquisador responsável, concordo em participar do
         estudo pesquisa GestBucalSD: AVALIAÇÃO DO USO DE PLATAFORMA WEB-BASED
@@ -242,18 +232,28 @@ const Index = forwardRef((props, ref) => {
         minha participação. Foi-me garantido que posso retirar o meu
         consentimento a qualquer momento, sem que isto leve a qualquer
         penalidade (ou interrupção de meu acompanhamento/
-        assistência/tratamento). Informe seu e-mail para enviarmos o termos.
-        Email:{" "}
-        <PDInput
-          placeholder="Email"
-          value={responsibleEmail}
-          onChange={(e) => setResponsibleEmail(e.target.value)}
-        />
+        assistência/tratamento). Informe seu e-mail para enviarmos o termo.
+      </PD>
+      <PD>
+        E-mail:{" "}
+        <FieldWrap>
+          <PDInput
+            placeholder="email@exemplo.com"
+            value={responsibleEmail}
+            style={{ borderBottomColor: emailError ? '#dc2626' : undefined }}
+            onChange={(e) => { setResponsibleEmail(e.target.value); if (emailError) setEmailError(""); }}
+            onBlur={() => {
+              if (responsibleEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(responsibleEmail))
+                setEmailError("E-mail inválido.");
+            }}
+          />
+          <FieldError msg={emailError} />
+        </FieldWrap>
       </PD>
     </DocumentData>
   );
 });
 
-Index.displayName = "TCLE";
+Index.displayName = "TCLEPROF";
 
 export default Index;

--- a/src/components/tcle/tcle-document/styled.tsx
+++ b/src/components/tcle/tcle-document/styled.tsx
@@ -21,45 +21,60 @@ export const TaleImage = styled.img`
 
 // Paragraphy Document
 export const PD = styled.p`
-  font-size: 1vw;
-  text-indent: 2vw;
+  font-size: 0.88rem;
+  font-family: 'Source Sans 3', -apple-system, BlinkMacSystemFont, sans-serif;
+  text-indent: 1.5em;
+  line-height: 1.7;
+  margin: 0.6em 0;
+  text-align: justify;
 
   @media (max-width: 768px) {
-    font-size: 4vw;
+    font-size: 3.5vw;
   }
 `;
 
 export const PDInput = styled.input`
   background-color: transparent;
   border: 0;
-  border-bottom: 1px solid black;
+  border-bottom: 1.5px solid #555;
   border-radius: 0;
-  width: 21vw;
-  margin-left: 0vw;
-  margin-right: 0;
-  height: 1vw;
+  width: 18vw;
+  height: 1.4em;
+  font-size: inherit;
+  font-family: 'Source Sans 3', -apple-system, BlinkMacSystemFont, sans-serif;
+  vertical-align: middle;
+  padding: 0 2px;
+  outline: none;
+  transition: border-color 0.2s;
+
+  &:focus {
+    border-bottom-color: ${theme.primaryColor};
+  }
 
   &::placeholder {
     color: ${theme.grey};
+    font-style: italic;
+    font-size: 0.85em;
   }
 
   @media (max-width: 768px) {
-    font-size: 4vw;
-    height: 4vw;
+    width: 40vw;
+    font-size: 3.5vw;
   }
 `;
 
 export const DocumentParagraphyTitle = styled.h5`
   text-align: center;
   width: 100%;
-  margin: 1vw 0;
-  & > b {
-    font-weight: bolder;
+  font-size: 0.85rem;
+  font-family: 'Source Sans 3', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-weight: 600;
+  margin: 1em 0 0.4em;
+  line-height: 1.5;
 
-    &::after {
-      content: "\\A";
-      white-space: pre;
-    }
+  & > b {
+    font-weight: 700;
+    display: block;
   }
 `;
 

--- a/src/components/toolbar/home/index.tsx
+++ b/src/components/toolbar/home/index.tsx
@@ -10,7 +10,6 @@ export default function Index() {
   const router = useRouter();
   const [isDrawerMenuOpen, setIsDrawerMenuOpen] = useState(false);
   const [menu, setMenu] = useState([
-    { id: 0, title: 'Questionário Inicial',    url: routerEnum.QUESTION },
     { id: 1, title: 'Questionários',           url: routerEnum.FORM },
     { id: 3, title: 'Planeja SD - Teórico',    url: routerEnum.PLANEJA },
     { id: 4, title: 'Planeja SD - Prático',    url: routerEnum.PLANEJA_PRATICO },

--- a/src/core/enums.ts
+++ b/src/core/enums.ts
@@ -41,7 +41,7 @@ export enum titleEnumPtBr {
     "/tcle" = "TCLE",
     "/direction" = "Endereço",
     "/form" = "Formularios",
-    "/question" = "Questionario inicial",
+    // "/question" = "Questionario inicial",
     "/planeja" = "PlanejaSD Teorico",
     "/planeja-pratico" = "PlanejaSD Pratico",
     "/ceo" = "Dados CEO",

--- a/src/core/utils/cpf.ts
+++ b/src/core/utils/cpf.ts
@@ -1,0 +1,26 @@
+export function maskCPF(value: string): string {
+  return value
+    .replace(/\D/g, '')
+    .slice(0, 11)
+    .replace(/(\d{3})(\d)/, '$1.$2')
+    .replace(/(\d{3})(\d)/, '$1.$2')
+    .replace(/(\d{3})(\d{1,2})$/, '$1-$2');
+}
+
+export function validateCPF(value: string): boolean {
+  const digits = value.replace(/\D/g, '');
+
+  if (digits.length !== 11) return false;
+  if (/^(\d)\1{10}$/.test(digits)) return false;
+
+  const calc = (len: number) => {
+    let sum = 0;
+    for (let i = 0; i < len; i++) {
+      sum += parseInt(digits[i]) * (len + 1 - i);
+    }
+    const remainder = (sum * 10) % 11;
+    return remainder === 10 || remainder === 11 ? 0 : remainder;
+  };
+
+  return calc(9) === parseInt(digits[9]) && calc(10) === parseInt(digits[10]);
+}

--- a/src/core/utils/date.ts
+++ b/src/core/utils/date.ts
@@ -1,0 +1,24 @@
+export function maskDate(value: string): string {
+  return value
+    .replace(/\D/g, '')
+    .slice(0, 8)
+    .replace(/(\d{2})(\d)/, '$1/$2')
+    .replace(/(\d{2})(\d)/, '$1/$2');
+}
+
+export function validateDate(value: string): boolean {
+  if (!/^\d{2}\/\d{2}\/\d{4}$/.test(value)) return false;
+
+  const [day, month, year] = value.split('/').map(Number);
+
+  if (month < 1 || month > 12) return false;
+  if (day < 1) return false;
+  if (year < 1900 || year > 2100) return false;
+
+  const date = new Date(year, month - 1, day);
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  );
+}

--- a/src/core/utils/phone.ts
+++ b/src/core/utils/phone.ts
@@ -1,0 +1,13 @@
+export function maskPhone(value: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 11);
+
+  if (digits.length <= 2) return digits.length ? `(${digits}` : '';
+  if (digits.length <= 6) return `(${digits.slice(0, 2)}) ${digits.slice(2)}`;
+  if (digits.length <= 10) return `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`;
+  return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+}
+
+export function validatePhone(value: string): boolean {
+  const digits = value.replace(/\D/g, '');
+  return digits.length === 10 || digits.length === 11;
+}

--- a/src/core/utils/rg.ts
+++ b/src/core/utils/rg.ts
@@ -1,0 +1,7 @@
+export function maskRG(value: string): string {
+    const digits = value.replace(/[^\dXx]/g, "").toUpperCase();
+    if (digits.length <= 2) return digits;
+    if (digits.length <= 5) return `${digits.slice(0, 2)}.${digits.slice(2)}`;
+    if (digits.length <= 8) return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5)}`;
+    return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}-${digits.slice(8, 9)}`;
+}

--- a/src/core/utils/text.ts
+++ b/src/core/utils/text.ts
@@ -1,0 +1,3 @@
+export function onlyLetters(value: string): string {
+  return value.replace(/[0-9]/g, '');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,11 +27,18 @@
       "@components/*": [
         "src/components/*"
       ]
-    }
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": false
   },
   "include": [
     "pages/**/*",
-    "src/**/*"
+    "src/**/*",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Melhorias nos formulários, termos de consentimento e redesign de interface
Redesign de interface
Listagem de formulários reformulada com layout em cards, ícone da logo, indicador "Requer assinatura de termos" e hover interativo
Footer redesenhado como barra horizontal única com marca, links de navegação e SAC
Toolbar home atualizada com novo estilo visual
Termos de consentimento (TCLE/TALE)
Validação inline nos campos dos documentos (TCLE, TCLE2, TCLEPROF, TALEU13, TALEU18) com exibição de erros por campo, máscara de CPF, telefone, data e RG
Modal de termos com estados independentes por tipo de termo — marcar um não afeta os demais
Badges visuais de status (Pendente / Concluído) para cada termo
Persistência dos termos assinados via sessionStorage, mantendo o estado ao navegar entre páginas
Modal sempre montado para preservar preenchimento ao fechar e reabrir
Validação de acesso
Rota /form-answer protegida: usuário sem os termos obrigatórios assinados é redirecionado para a listagem com aviso
Correções
Propagação de errorIds para questões filhas no formulário, corrigindo o botão "Enviar" que não respondia em determinados formulários
Feedback via snackbar ao tentar enviar formulário com questões obrigatórias em branco
Correção do replaceChild no exportador de PDF dos termos