### PR TITLE
Add multiple selection support with checkboxes and update term display logic for the new form

### DIFF
--- a/src/app/form-answer/page.tsx
+++ b/src/app/form-answer/page.tsx
@@ -28,7 +28,7 @@ function FormAnswerContent() {
     const [formResult, setFormResult] = useState<GET_USER_RESULT_FROM_FORM_RES | null>();
 
     function hasSignedRequiredTerm(id: number): boolean {
-        if ([1, 3, 4].includes(id)) return sessionStorage.getItem('tcle_TCLEPROF') === '1';
+        if ([1, 3, 4, 15].includes(id)) return sessionStorage.getItem('tcle_TCLEPROF') === '1';
         if (id === 6 || id === 2) return sessionStorage.getItem('tcle_TCLE') === '1' || sessionStorage.getItem('tcle_TCLE2') === '1';
         return sessionStorage.getItem('tcle_TCLE') === '1';
     }

--- a/src/components/answer/choice/index.tsx
+++ b/src/components/answer/choice/index.tsx
@@ -129,6 +129,7 @@ export default function Index(props: TPROPS) {
 										padding: '10px 14px',
 										borderRadius: '10px',
 										border: `1.5px solid ${C.border}`,
+										backgroundColor: '#ffffff',
 										fontFamily: ff.body,
 										fontSize: '15px',
 										color: C.text,

--- a/src/components/answer/choice/index.tsx
+++ b/src/components/answer/choice/index.tsx
@@ -9,12 +9,30 @@ export default function Index(props: TPROPS) {
 	const [answer, setAnswer] = React.useState<number[]>(Array(props.choices.length).fill(0));
 	const [selected, setSelected] = React.useState<number | null>(null);
 
+	// Checkbox mode state
+	const [checkedIndices, setCheckedIndices] = React.useState<Set<number>>(new Set());
+	const [outraText, setOutraText] = React.useState('');
+
 	const handleSelectChoice = (index: number, choice: CHOICE) => {
 		const temp = answer.slice();
 		temp.fill(0);
 		temp[index] = Number(choice.formsQuestionFormsQuestionChoicesId);
 		setAnswer(temp);
 		setSelected(index);
+		props.onSelectChoice({ formQuestionFormRegisterId: props.formQuestionFormRegisterId, answer: JSON.stringify(temp) });
+	};
+
+	const handleCheckboxToggle = (index: number, choice: CHOICE) => {
+		const next = new Set(checkedIndices);
+		if (next.has(index)) {
+			next.delete(index);
+			if (choice.title.toLowerCase().includes('outra')) setOutraText('');
+		} else {
+			next.add(index);
+		}
+		setCheckedIndices(next);
+		const temp = Array(props.choices.length).fill(0);
+		next.forEach((i) => { temp[i] = Number(props.choices[i].formsQuestionFormsQuestionChoicesId); });
 		props.onSelectChoice({ formQuestionFormRegisterId: props.formQuestionFormRegisterId, answer: JSON.stringify(temp) });
 	};
 
@@ -41,6 +59,88 @@ export default function Index(props: TPROPS) {
 					handleSelectChoice(index, props.choices[index]);
 				}}
 			/>
+		);
+	}
+
+	if (props.choiceType === 'checkbox') {
+		return (
+			<div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+				{props.choices.map((choice, index) => {
+					const isChecked = checkedIndices.has(index);
+					const isOutra = choice.title.toLowerCase().includes('outra');
+					return (
+						<React.Fragment key={index}>
+							<label
+								onClick={() => handleCheckboxToggle(index, choice)}
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									gap: '12px',
+									padding: '10px 14px',
+									borderRadius: '10px',
+									border: `1.5px solid ${isChecked ? C.primary : C.border}`,
+									backgroundColor: isChecked ? 'rgba(109,20,26,0.04)' : 'transparent',
+									cursor: 'pointer',
+									transition: 'all 0.2s ease',
+								}}
+								onMouseEnter={(e) => { if (!isChecked) e.currentTarget.style.borderColor = '#a8a29e'; }}
+								onMouseLeave={(e) => { if (!isChecked) e.currentTarget.style.borderColor = isChecked ? C.primary : C.border; }}
+							>
+								<div style={{
+									width: '18px', height: '18px', borderRadius: '4px', flexShrink: 0,
+									border: `2px solid ${isChecked ? C.primary : '#a8a29e'}`,
+									backgroundColor: isChecked ? C.primary : 'transparent',
+									display: 'flex', alignItems: 'center', justifyContent: 'center',
+									transition: 'all 0.2s ease',
+								}}>
+									{isChecked && (
+										<svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+											<path d="M2 6l3 3 5-5" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+										</svg>
+									)}
+								</div>
+								<span style={{
+									fontFamily: ff.body,
+									fontSize: '15px',
+									color: isChecked ? C.primary : C.text,
+									fontWeight: isChecked ? 600 : 400,
+									lineHeight: 1.4,
+									transition: 'color 0.2s',
+								}}>
+									{choice.title}
+								</span>
+							</label>
+							{isOutra && isChecked && (
+								<input
+									type="text"
+									placeholder="Especifique a especialidade"
+									value={outraText}
+									onChange={(e) => {
+										setOutraText(e.target.value);
+										const temp = Array(props.choices.length).fill(0);
+										checkedIndices.forEach((i) => { temp[i] = Number(props.choices[i].formsQuestionFormsQuestionChoicesId); });
+										props.onSelectChoice({
+											formQuestionFormRegisterId: props.formQuestionFormRegisterId,
+											answer: JSON.stringify({ choices: temp, outra: e.target.value }),
+										});
+									}}
+									style={{
+										width: '100%',
+										padding: '10px 14px',
+										borderRadius: '10px',
+										border: `1.5px solid ${C.border}`,
+										fontFamily: ff.body,
+										fontSize: '15px',
+										color: C.text,
+										outline: 'none',
+										boxSizing: 'border-box',
+									}}
+								/>
+							)}
+						</React.Fragment>
+					);
+				})}
+			</div>
 		);
 	}
 

--- a/src/components/answer/choice/index.tsx
+++ b/src/components/answer/choice/index.tsx
@@ -11,7 +11,7 @@ export default function Index(props: TPROPS) {
 
 	// Checkbox mode state
 	const [checkedIndices, setCheckedIndices] = React.useState<Set<number>>(new Set());
-	const [outraText, setOutraText] = React.useState('');
+	const [otherText, setOtherText] = React.useState('');
 
 	const handleSelectChoice = (index: number, choice: CHOICE) => {
 		const temp = answer.slice();
@@ -24,12 +24,9 @@ export default function Index(props: TPROPS) {
 
 	const handleCheckboxToggle = (index: number, choice: CHOICE) => {
 		const next = new Set(checkedIndices);
-		if (next.has(index)) {
-			next.delete(index);
-			if (choice.title.toLowerCase().includes('outra')) setOutraText('');
-		} else {
-			next.add(index);
-		}
+		const removing = next.has(index);
+		removing ? next.delete(index) : next.add(index);
+		if (removing && choice.title.toLowerCase().includes('outra')) setOtherText('');
 		setCheckedIndices(next);
 		const temp = Array(props.choices.length).fill(0);
 		next.forEach((i) => { temp[i] = Number(props.choices[i].formsQuestionFormsQuestionChoicesId); });
@@ -67,7 +64,7 @@ export default function Index(props: TPROPS) {
 			<div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
 				{props.choices.map((choice, index) => {
 					const isChecked = checkedIndices.has(index);
-					const isOutra = choice.title.toLowerCase().includes('outra');
+					const isOther = choice.title.toLowerCase().includes('outra');
 					return (
 						<React.Fragment key={index}>
 							<label
@@ -110,13 +107,13 @@ export default function Index(props: TPROPS) {
 									{choice.title}
 								</span>
 							</label>
-							{isOutra && isChecked && (
+							{isOther && isChecked && (
 								<input
 									type="text"
 									placeholder="Especifique a especialidade"
-									value={outraText}
+									value={otherText}
 									onChange={(e) => {
-										setOutraText(e.target.value);
+										setOtherText(e.target.value);
 										const temp = Array(props.choices.length).fill(0);
 										checkedIndices.forEach((i) => { temp[i] = Number(props.choices[i].formsQuestionFormsQuestionChoicesId); });
 										props.onSelectChoice({

--- a/src/components/answer/choice/type.ts
+++ b/src/components/answer/choice/type.ts
@@ -5,7 +5,7 @@ export type TPROPS = {
 	formQuestionFormRegisterId: ID;
 	choices: CHOICE[];
 	onSelectChoice: (value: QUESTION_ANSWER) => void;
-	choiceType?:'radio' | 'autoComplete'
+	choiceType?:'radio' | 'autoComplete' | 'checkbox'
 };
 
 export type CHOICE = {

--- a/src/components/answer/open/index.tsx
+++ b/src/components/answer/open/index.tsx
@@ -1,8 +1,16 @@
 import { TPROPS } from './type';
 
 export default function Index(props: TPROPS) {
+	const isNumeric = props.inputType === 'number';
+
 	const handleAnswerQuestion = (answer: string) => {
 		props.onAnswerQuestion({ formQuestionFormRegisterId: props.formQuestionFormRegisterId, answer });
+	};
+
+	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const val = isNumeric ? e.target.value.replace(/\D/g, '') : e.target.value;
+		handleAnswerQuestion(val);
+		if (isNumeric) e.target.value = val;
 	};
 
 	return (
@@ -19,9 +27,11 @@ export default function Index(props: TPROPS) {
 			<input
 				className="gestbucal-input"
 				type="text"
+				inputMode={isNumeric ? 'numeric' : 'text'}
+				pattern={isNumeric ? '[0-9]*' : undefined}
 				placeholder={props.placeholder || 'Digite sua resposta...'}
-				onChange={(e) => handleAnswerQuestion(e.target.value)}
-				onBlur={(e) => handleAnswerQuestion(e.target.value)}
+				onChange={handleChange}
+				onBlur={(e) => handleAnswerQuestion(isNumeric ? e.target.value.replace(/\D/g, '') : e.target.value)}
 				style={{
 					width: '100%',
 					padding: '10px 12px',

--- a/src/components/answer/open/type.ts
+++ b/src/components/answer/open/type.ts
@@ -4,5 +4,6 @@ import { QUESTION_ANSWER } from '../../question/type';
 export type TPROPS = {
 	formQuestionFormRegisterId: ID;
 	placeholder?: string;
+	inputType?: 'text' | 'number';
 	onAnswerQuestion: (value: QUESTION_ANSWER) => void;
 };

--- a/src/components/question/index.tsx
+++ b/src/components/question/index.tsx
@@ -138,7 +138,7 @@ export default function Index(props: TPROPS) {
 
                                 handleAnswerQuestion(data);
                             }}
-                            choiceType={selectOptions.includes(props.question.formQuestionFormRegisterId) ? "autoComplete" : "radio"}
+                            choiceType={selectOptions.includes(props.question.formQuestionFormRegisterId) ? "autoComplete" : props.question.type.cod === 'MC' ? "checkbox" : "radio"}
                         />
                     )}
                     {hasError && (

--- a/src/components/question/index.tsx
+++ b/src/components/question/index.tsx
@@ -98,6 +98,7 @@ export default function Index(props: TPROPS) {
                         <OpenAnswer
                             formQuestionFormRegisterId={props.question.formQuestionFormRegisterId}
                             placeholder={props.question.completionMessage || undefined}
+                            inputType={/idade|quanto tempo|ano[s]?|número|numeração/i.test(props.question.title) ? 'number' : 'text'}
                             onAnswerQuestion={(data) => {
                                 handleAnswerQuestion(data);
                             }}

--- a/src/components/tcle/index.tsx
+++ b/src/components/tcle/index.tsx
@@ -330,7 +330,7 @@ export default function TcleModal(props: Props) {
                             <TermsText
                                 $checked={checkedTCLEPROF}
                                 style={{
-                                    display: props.idForm == "1" || props.idForm == "3" || props.idForm == "4" ? "" : "none",
+                                    display: props.idForm == "1" || props.idForm == "3" || props.idForm == "4" || props.idForm == "15" ? "" : "none",
                                     cursor: checkedTCLEPROF ? 'default' : 'pointer',
                                     pointerEvents: checkedTCLEPROF ? 'none' : 'auto',
                                 }}


### PR DESCRIPTION
This pull request adds support for checkbox questions in the response selection interface and updates the logic related to required terms to comply with the new `'Satisfação Profissional dos CD'` form.

**Related:**

PR  BE: [#43](https://github.com/runmand/api-plataforma-sbufpe/pull/43)

**Support for Checkbox Questions:**

* Added checkbox input mode to the `Index` component in `src/components/answer/choice/index.tsx`, including state management for checked choices, "Outra" (Other) text handling, and UI rendering for checkboxes. [[1]](diffhunk://#diff-c9d1fc27a1fbce8cea18342fed584ec94e997272ad08c261fd13eff0cf32d994R12-R15) [[2]](diffhunk://#diff-c9d1fc27a1fbce8cea18342fed584ec94e997272ad08c261fd13eff0cf32d994R25-R38) [[3]](diffhunk://#diff-c9d1fc27a1fbce8cea18342fed584ec94e997272ad08c261fd13eff0cf32d994R65-R146)
* Updated the `TPROPS` type in `src/components/answer/choice/type.ts` to include `'checkbox'` as a valid `choiceType`.
* Modified the question rendering logic in `src/components/question/index.tsx` to use the checkbox mode for questions with type code `'MC'`.

**Required Terms Logic:**

* Updated the `hasSignedRequiredTerm` function in `src/app/form-answer/page.tsx` to include form ID 15 in the check for the `tcle_TCLEPROF` term.
* Extended the display logic for the professional terms section in `src/components/tcle/index.tsx` to include form ID 15.