### PR TITLE
Add post-login census TCLE consent gate

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { theme } from 'src/core/theme';
 import { setSnackbarRef } from 'src/core/snackbar';
 import CustomSnackbar from 'src/components/snackbar';
+import CensoConsentModal from '@components/modal/censo-consent';
 
 function SnackbarConfigurator(): null {
     const ctx = useSnackbar();
@@ -31,6 +32,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
                 anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
             >
                 <SnackbarConfigurator />
+                <CensoConsentModal />
                 {children}
             </SnackbarProvider>
         </ThemeProvider>

--- a/src/app/tcle-censo/page.tsx
+++ b/src/app/tcle-censo/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect } from 'react';
+import Base from '@components/base-layout/index';
+import NewMenu from '@components/newMenu/index';
+import TcleCenso from '@components/container/tcle-censo';
+import FooterMain from '@components/footer/main/index';
+
+export default function Page() {
+    useEffect(() => {
+        document.title = 'TCLE do Censo | GestBucal';
+    }, []);
+
+    return (
+        <Base appBarChild={<NewMenu />} mainContainerChild={<TcleCenso />} footerChild={<FooterMain />} />
+    );
+}

--- a/src/components/container/tcle-censo/index.tsx
+++ b/src/components/container/tcle-censo/index.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
+import {
+    censoTermIntro,
+    censoTermSections,
+    censoTermDeclarationHeading,
+    censoTermDeclarationIntro,
+    censoTermAcceptLabel,
+    censoTermDeclineLabel,
+    censoTermResearcher,
+} from "@components/tcle-censo/content";
+
+export default function Index() {
+    return (
+        <div className="bg-[#f5f5f4] min-h-[88vh] pt-20 sm:pt-24 pb-12 px-4">
+            <div className="max-w-[860px] mx-auto">
+                {/* Page header */}
+                <div className="text-center mb-6">
+                    <div className="inline-flex items-center justify-center w-14 h-14 rounded-xl bg-gb-primary mb-3">
+                        <DescriptionOutlinedIcon style={{ color: "#ffffff", fontSize: 28 }} />
+                    </div>
+                    <h1
+                        className="font-display text-[28px] sm:text-[32px] font-bold text-gb-text leading-tight tracking-tight"
+                        style={{ background: "transparent" }}
+                    >
+                        TCLE do Censo CEO/SESB
+                    </h1>
+                    <p className="text-sm text-gb-muted leading-relaxed mt-1.5 max-w-[560px] mx-auto">
+                        Termo de Consentimento Livre e Esclarecido referente à coleta de dados virtual do Censo Nacional dos CEO e SESB.
+                    </p>
+                </div>
+
+                {/* Content card */}
+                <div className="bg-white rounded-2xl shadow-lg p-6 sm:p-10 font-body" style={{ border: "1px solid #e7e5e4" }}>
+                    <div className="mb-6 pb-5" style={{ borderBottom: "1px solid #e7e5e4" }}>
+                        <span className="inline-block text-[11px] font-bold tracking-widest uppercase text-gb-primary mb-2">
+                            Coleta de dados virtual
+                        </span>
+                        <h2 className="font-display text-[22px] sm:text-[26px] font-bold text-gb-text leading-tight tracking-tight">
+                            Termo de Consentimento Livre e Esclarecido — TCLE
+                        </h2>
+                    </div>
+
+                    <div className="space-y-5">
+                        {censoTermIntro.map((text, i) => (
+                            <p key={`intro-${i}`} className="text-[14.5px] text-gb-text leading-relaxed text-justify" style={{ textIndent: "1.5rem" }}>
+                                {text}
+                            </p>
+                        ))}
+
+                        {censoTermSections.map((section) => (
+                            <div key={section.heading}>
+                                <h3 className="text-[11px] font-bold tracking-widest uppercase text-gb-label mb-2">
+                                    {section.heading}
+                                </h3>
+                                {section.paragraphs.map((p, i) => (
+                                    <p key={i} className="text-[14.5px] text-gb-text leading-relaxed text-justify mb-2" style={{ textIndent: "1.5rem" }}>
+                                        {p}
+                                    </p>
+                                ))}
+                            </div>
+                        ))}
+
+                        <div>
+                            <h3 className="text-[11px] font-bold tracking-widest uppercase text-gb-label mb-2">
+                                {censoTermDeclarationHeading}
+                            </h3>
+                            <p className="text-[14.5px] text-gb-text leading-relaxed text-justify mb-3" style={{ textIndent: "1.5rem" }}>
+                                {censoTermDeclarationIntro}
+                            </p>
+                            <p className="text-[14.5px] text-gb-text leading-relaxed mb-1">☐ {censoTermAcceptLabel}</p>
+                            <p className="text-[14.5px] text-gb-text leading-relaxed">☐ {censoTermDeclineLabel}</p>
+                        </div>
+
+                        <p className="text-[13px] text-gb-muted text-right pt-4" style={{ borderTop: "1px solid #e7e5e4" }}>
+                            {censoTermResearcher}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/footer/main/index.tsx
+++ b/src/components/footer/main/index.tsx
@@ -9,6 +9,7 @@ const links = [
     { label: "faq",        url: routerEnum.FAQ },
     { label: "contato",    url: routerEnum.CONTACTUS },
     { label: "tcle",       url: routerEnum.TCLE },
+    { label: "tcle censo", url: routerEnum.TCLE_CENSO },
     { label: "acervo",     url: routerEnum.ARTICLES },
 ];
 

--- a/src/components/modal/censo-consent/index.tsx
+++ b/src/components/modal/censo-consent/index.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Modal, Box, useMediaQuery } from "@mui/material";
+import { DocumentContainer, DocumentData, DocumentTitle, TermScrollArea, TermsButton, TermsButtonContainer, TermsText } from "@components/tcle/styled";
+import { PD, DocumentParagraphyTitle } from "@components/tcle/tcle-document/styled";
+import { useSnackbar } from "notistack";
+import { useRouter } from "next/navigation";
+import { http } from "src/core/axios";
+import type { DataTerm } from "@components/tcle";
+import { generatePDF } from "@components/tcle/exportpdf";
+import { emitterWindowEventEnum, localStorageKeyEnum, routerEnum } from "src/core/enums";
+import {
+    censoTermIntro,
+    censoTermSections,
+    censoTermDeclarationHeading,
+    censoTermDeclarationIntro,
+    censoTermAcceptLabel,
+    censoTermDeclineLabel,
+} from "@components/tcle-censo/content";
+
+const LOGOUT_WARNING_SECONDS = 10;
+
+// Rota provisória — ainda não implementada no backend. Espelha o contrato de
+// POST /term/send (mesmo formato de DataTerm), mas sem formId por não estar
+// atrelada a um formulário específico. Alinhar com o time de backend antes de subir.
+const CENSO_TERM_SEND_URL = "/term/censo/send";
+
+type Choice = "accept" | "decline";
+
+const getStatusKey = (userId: string) => `${localStorageKeyEnum.CENSO_TCLE_STATUS}_${userId}`;
+
+export default function CensoConsentModal() {
+    const [open, setOpen] = useState(false);
+    const [hasReadTerm, setHasReadTerm] = useState(false);
+    const [choice, setChoice] = useState<Choice | null>(null);
+    const [showLogoutWarning, setShowLogoutWarning] = useState(false);
+    const [logoutCountdown, setLogoutCountdown] = useState(LOGOUT_WARNING_SECONDS);
+    const [submitting, setSubmitting] = useState(false);
+    const largeQuery = useMediaQuery("(min-width:720px)");
+    const { enqueueSnackbar } = useSnackbar();
+    const router = useRouter();
+    const finalizeDeclineAndLogoutRef = useRef<() => void>(() => {});
+    const hasFinalizedRef = useRef(false);
+
+    /**
+     * PROVISÓRIO: a checagem de aceite hoje é 100% client-side (localStorage),
+     * então é trivialmente contornável via DevTools. Isso deve ser substituído
+     * assim que o backend expuser uma forma autoritativa de saber se a conta
+     * já aceitou o termo (ex.: um campo no retorno do login, ou um
+     * GET /term/censo/status) — aí o valor do servidor manda, e o localStorage
+     * vira só um cache/fallback offline.
+     */
+    const checkAndMaybeOpen = useCallback(() => {
+        const token = localStorage.getItem(localStorageKeyEnum.TOKEN);
+        const userId = localStorage.getItem(localStorageKeyEnum.USER_ID);
+        if (!token || !userId) return;
+
+        // Só "accept" dispensa o gate. Uma recusa anterior não deve liberar
+        // logins futuros sem que o termo seja de fato aceito.
+        const raw = localStorage.getItem(getStatusKey(userId));
+        const status = raw ? (JSON.parse(raw) as { status?: Choice }).status : null;
+
+        if (status !== "accept") {
+            setHasReadTerm(false);
+            setChoice(null);
+            setOpen(true);
+        }
+    }, []);
+
+    useEffect(() => {
+        checkAndMaybeOpen();
+        window.addEventListener(emitterWindowEventEnum.LOGIN_SUCCESS, checkAndMaybeOpen);
+        return () => window.removeEventListener(emitterWindowEventEnum.LOGIN_SUCCESS, checkAndMaybeOpen);
+    }, [checkAndMaybeOpen]);
+
+    useEffect(() => {
+        if (!showLogoutWarning) return;
+
+        hasFinalizedRef.current = false;
+        let remaining = LOGOUT_WARNING_SECONDS;
+        setLogoutCountdown(remaining);
+
+        const interval = setInterval(() => {
+            remaining -= 1;
+            setLogoutCountdown(Math.max(remaining, 0));
+
+            if (remaining <= 0) {
+                clearInterval(interval);
+                finalizeDeclineAndLogoutRef.current();
+            }
+        }, 1000);
+
+        return () => clearInterval(interval);
+    }, [showLogoutWarning]);
+
+    const handleTermScroll = (e: React.UIEvent<HTMLDivElement>) => {
+        const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
+        if (scrollTop + clientHeight >= scrollHeight - 30) setHasReadTerm(true);
+    };
+
+    /**
+     * Envia o registro do consentimento (aceite ou recusa) para o backend.
+     * O endpoint ainda não existe — falha aqui é esperada até o backend
+     * implementar CENSO_TERM_SEND_URL; por isso não bloqueia o fluxo local.
+     */
+    const submitToBackend = async (valid: boolean, userId: string) => {
+        try {
+            const node = document.getElementById("TCLE_CENSO")?.children;
+            const pdf = node ? await generatePDF(node) : "";
+
+            const tcle: DataTerm = {
+                valid,
+                type: "TCLE_CENSO",
+                email: "",
+                account: Number(userId),
+                pdf,
+                created_at: new Date(),
+            };
+
+            await http.post(CENSO_TERM_SEND_URL, { tcle }, { silent: true });
+        } catch (err) {
+            console.error("censo-consent:submitToBackend", err);
+        }
+    };
+
+    const handleConfirm = async () => {
+        if (!choice || submitting) return;
+
+        if (choice === "decline") {
+            setShowLogoutWarning(true);
+            return;
+        }
+
+        const userId = localStorage.getItem(localStorageKeyEnum.USER_ID);
+        if (!userId) return;
+
+        setSubmitting(true);
+        await submitToBackend(true, userId);
+        setSubmitting(false);
+
+        localStorage.setItem(getStatusKey(userId), JSON.stringify({ status: "accept", respondedAt: new Date().toISOString() }));
+        enqueueSnackbar("Consentimento registrado. Obrigado por participar da pesquisa!", { variant: "success" });
+        setOpen(false);
+    };
+
+    const finalizeDeclineAndLogout = async () => {
+        if (hasFinalizedRef.current) return;
+        hasFinalizedRef.current = true;
+
+        const userId = localStorage.getItem(localStorageKeyEnum.USER_ID);
+
+        setSubmitting(true);
+        if (userId) await submitToBackend(false, userId);
+        setSubmitting(false);
+
+        if (userId) {
+            localStorage.setItem(getStatusKey(userId), JSON.stringify({ status: "decline", respondedAt: new Date().toISOString() }));
+        }
+
+        localStorage.removeItem(localStorageKeyEnum.TOKEN);
+        localStorage.removeItem(localStorageKeyEnum.TYPE_ID);
+        localStorage.removeItem(localStorageKeyEnum.USER_ID);
+
+        enqueueSnackbar("Você foi desconectado por não aceitar o termo de consentimento.", { variant: "info" });
+        setOpen(false);
+        setShowLogoutWarning(false);
+        router.push(routerEnum.INITIAL);
+    };
+
+    // Mantém a ref sempre apontando para a versão mais recente da função,
+    // para que o setInterval (que não é recriado a cada render) possa chamá-la.
+    finalizeDeclineAndLogoutRef.current = finalizeDeclineAndLogout;
+
+    if (!open) return null;
+
+    return (
+        <Modal
+            sx={{ width: largeQuery ? "60vw" : "100vw", margin: largeQuery ? "auto" : "0" }}
+            open={open}
+            disableEscapeKeyDown
+            onClose={() => { /* mandatory gate: dismissible only via an explicit choice */ }}
+        >
+            <Box
+                sx={{
+                    position: "absolute",
+                    top: "50%",
+                    left: "50%",
+                    transform: "translate(-50%, -50%)",
+                    width: "100%",
+                    maxHeight: "92vh",
+                    overflowY: "auto",
+                    bgcolor: "background.paper",
+                    boxShadow: 24,
+                    borderRadius: 3,
+                    p: 3,
+                    boxSizing: "border-box",
+                }}
+            >
+                <DocumentContainer style={{ height: "50vh" }}>
+                    <DocumentTitle>Termo de Consentimento Livre e Esclarecido — Censo CEO/SESB</DocumentTitle>
+
+                    <TermScrollArea onScroll={handleTermScroll}>
+                        <DocumentData id="TCLE_CENSO">
+                            <DocumentParagraphyTitle>
+                                <b>COLETA DE DADOS VIRTUAL</b>
+                            </DocumentParagraphyTitle>
+
+                            {censoTermIntro.map((text, i) => <PD key={`intro-${i}`}>{text}</PD>)}
+
+                            {censoTermSections.map((section) => (
+                                <React.Fragment key={section.heading}>
+                                    <DocumentParagraphyTitle><b>{section.heading}</b></DocumentParagraphyTitle>
+                                    {section.paragraphs.map((p, i) => <PD key={i}>{p}</PD>)}
+                                </React.Fragment>
+                            ))}
+
+                            <DocumentParagraphyTitle><b>{censoTermDeclarationHeading}</b></DocumentParagraphyTitle>
+                            <PD>{censoTermDeclarationIntro}</PD>
+                        </DocumentData>
+                    </TermScrollArea>
+
+                    {!hasReadTerm && (
+                        <div style={{
+                            display: 'flex', alignItems: 'center', gap: '8px', justifyContent: 'center',
+                            backgroundColor: 'rgba(217,119,6,0.06)', border: '1px solid rgba(217,119,6,0.2)',
+                            borderRadius: '10px', padding: '8px 14px', margin: '8px 0 0',
+                        }}>
+                            <svg width="15" height="15" fill="none" viewBox="0 0 24 24" stroke="#d97706" strokeWidth={2} style={{ flexShrink: 0 }}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+                            </svg>
+                            <p style={{ margin: 0, fontSize: '0.78rem', color: '#92400e', fontWeight: 600, lineHeight: 1.4, textAlign: 'center', fontFamily: "'Source Sans 3', sans-serif" }}>
+                                Leia atentamente todo o documento acima. As opções de aceite só são liberadas depois de você rolar até a última linha do texto.
+                            </p>
+                        </div>
+                    )}
+                </DocumentContainer>
+
+                {hasReadTerm && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, margin: '16px 0' }}>
+                        <TermsText $checked={choice === "accept"} onClick={() => setChoice("accept")}>
+                            <span style={{ flex: 1, fontSize: '0.85rem', fontWeight: 600, color: '#1c1917' }}>{censoTermAcceptLabel}</span>
+                        </TermsText>
+                        <TermsText $checked={choice === "decline"} onClick={() => setChoice("decline")}>
+                            <span style={{ flex: 1, fontSize: '0.85rem', fontWeight: 600, color: '#1c1917' }}>{censoTermDeclineLabel}</span>
+                        </TermsText>
+                    </div>
+                )}
+
+                <p style={{ textAlign: 'center', margin: '12px 0' }}>
+                    <button
+                        type="button"
+                        onClick={() => window.open(routerEnum.TCLE_CENSO, '_blank')}
+                        style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: '#6D141A', fontSize: '0.78rem', fontWeight: 600, textDecoration: 'underline' }}
+                    >
+                        Ver termo completo em uma nova aba
+                    </button>
+                </p>
+
+                <TermsButtonContainer style={{ gridTemplateColumns: '100%', marginTop: 4 }}>
+                    <TermsButton
+                        disabled={!hasReadTerm || !choice || submitting}
+                        onClick={hasReadTerm && choice && !submitting ? handleConfirm : undefined}
+                        style={{
+                            opacity: hasReadTerm && choice && !submitting ? 1 : 0.45,
+                            cursor: hasReadTerm && choice && !submitting ? 'pointer' : 'not-allowed',
+                        }}
+                    >
+                        {submitting ? 'Enviando...' : 'Confirmar'}
+                    </TermsButton>
+                </TermsButtonContainer>
+
+                {showLogoutWarning && (
+                    <div style={{
+                        position: 'absolute', inset: 0, borderRadius: '12px',
+                        backgroundColor: 'rgba(0,0,0,0.5)',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        zIndex: 10,
+                    }}>
+                        <div style={{
+                            backgroundColor: '#fff', borderRadius: '16px',
+                            padding: '28px 28px 24px', maxWidth: '380px', width: '90%',
+                            boxShadow: '0 20px 60px rgba(0,0,0,0.2)',
+                            display: 'flex', flexDirection: 'column', gap: '16px',
+                        }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                                <span style={{
+                                    width: 36, height: 36, borderRadius: '50%', flexShrink: 0,
+                                    backgroundColor: 'rgba(217,119,6,0.1)',
+                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                }}>
+                                    <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="#d97706" strokeWidth={2}>
+                                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                                    </svg>
+                                </span>
+                                <span style={{ fontSize: '0.95rem', fontWeight: 700, color: '#1c1917', fontFamily: "'Source Sans 3', sans-serif" }}>
+                                    Você será desconectado
+                                </span>
+                            </div>
+                            <p style={{ margin: 0, fontSize: '0.83rem', color: '#57534e', lineHeight: 1.6, fontFamily: "'Source Sans 3', sans-serif" }}>
+                                O aceite deste termo é necessário para continuar utilizando a plataforma. Como você optou por <strong>não participar da pesquisa</strong>, sua sessão será encerrada automaticamente em instantes — ou clique em "Sair agora" para sair imediatamente. Você pode fazer login novamente a qualquer momento caso queira reconsiderar.
+                            </p>
+                            <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+                                <button
+                                    disabled={submitting}
+                                    onClick={() => setShowLogoutWarning(false)}
+                                    style={{
+                                        padding: '8px 18px', borderRadius: '8px', border: '1.5px solid #e7e5e4',
+                                        background: '#fff', color: '#57534e', fontSize: '0.83rem', fontWeight: 600,
+                                        cursor: submitting ? 'not-allowed' : 'pointer', fontFamily: "'Source Sans 3', sans-serif",
+                                    }}
+                                >
+                                    Voltar
+                                </button>
+                                <button
+                                    disabled={submitting}
+                                    onClick={finalizeDeclineAndLogout}
+                                    style={{
+                                        padding: '8px 18px', borderRadius: '8px', border: 'none',
+                                        background: submitting ? '#c9a3a6' : '#6D141A', color: '#fff',
+                                        fontSize: '0.83rem', fontWeight: 700, minWidth: '140px',
+                                        cursor: submitting ? 'not-allowed' : 'pointer',
+                                        fontFamily: "'Source Sans 3', sans-serif",
+                                    }}
+                                >
+                                    {submitting ? 'Enviando...' : `Sair agora (${logoutCountdown}s)`}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </Box>
+        </Modal>
+    );
+}

--- a/src/components/modal/log-in/index.tsx
+++ b/src/components/modal/log-in/index.tsx
@@ -6,7 +6,7 @@ import CustomTextField from "@components/text-field/index";
 import LoginService from "./service";
 import { useSnackbar } from "notistack";
 import { useRouter } from "next/navigation";
-import { localStorageKeyEnum, loginTypeEnum, routerEnum } from "src/core/enums";
+import { emitterWindowEventEnum, localStorageKeyEnum, loginTypeEnum, routerEnum } from "src/core/enums";
 import CloseIcon from "@mui/icons-material/Close";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 
@@ -50,6 +50,7 @@ export default function Index(props: TPROPS) {
                     localStorage.setItem(localStorageKeyEnum.TOKEN, res.data.token);
                     localStorage.setItem(localStorageKeyEnum.USER_ID, res.data.user_id + "");
                     localStorage.setItem(localStorageKeyEnum.TYPE_ID, res.data.user_type.typeId + "");
+                    window.dispatchEvent(new Event(emitterWindowEventEnum.LOGIN_SUCCESS));
                     router.push(routerEnum.FORM);
                 } else {
                     setIsLoading(false);

--- a/src/components/modal/sign-up/index.tsx
+++ b/src/components/modal/sign-up/index.tsx
@@ -5,7 +5,7 @@ import { TPROPS, USER_TYPE } from "./type";
 import CustomTextField from "@components/text-field/index";
 import { useSnackbar } from "notistack";
 import { useRouter } from "next/navigation";
-import { localStorageKeyEnum, loginTypeEnum, routerEnum } from "src/core/enums";
+import { emitterWindowEventEnum, localStorageKeyEnum, loginTypeEnum, routerEnum } from "src/core/enums";
 import SignupService from "./service";
 import CloseIcon from "@mui/icons-material/Close";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
@@ -85,6 +85,7 @@ export default function Index(props: TPROPS) {
                     enqueueSnackbar("Registro efetuado com sucesso!", { variant: "success" });
                     localStorage.setItem(localStorageKeyEnum.TOKEN, res.data.token);
                     localStorage.setItem(localStorageKeyEnum.TYPE_ID, res.data.user_type.typeId + "");
+                    window.dispatchEvent(new Event(emitterWindowEventEnum.LOGIN_SUCCESS));
                     router.push(routerEnum.FORM);
                 } else {
                     setIsLoading(false);

--- a/src/components/tcle-censo/content.ts
+++ b/src/components/tcle-censo/content.ts
@@ -1,0 +1,69 @@
+export type CensoTermSection = { heading: string; paragraphs: string[] };
+
+export const censoTermIntro: string[] = [
+    "Convidamos o(a) Sr.(a) a participar, de forma voluntária, da pesquisa CENSO NACIONAL DOS CENTROS DE ESPECIALIDADES ODONTOLÓGICAS (CEO) E DOS SERVIÇOS DE ESPECIALIDADES ODONTOLÓGICAS (SESB), sob responsabilidade dos pesquisadores: Paulo Sávio Angeiras de Góes, Av. da Engenharia, Cidade Universitária, Departamento de Clínica e Odontologia Preventiva, Centro de Ciências da Saúde, UFPE, Recife-PE, CEP: 50670-420, telefone: (81) 99175-5763, e-mail: paulo.saviogoes@ufpe.br; Nilcema Figueiredo, telefone: (81) 99975-1015, e-mail: nilcema.figueiredo@ufpe.br; João Alves Gonçalves Neto, telefone: (19) 99864-9978, e-mail: joao.alvesn@ufpe.br; Amanda Maria Chaves, telefone: (81) 9655-5073, e-mail: amc5@cin.ufpe.br; e Gabriela da Silveira Gaspar, telefone: (81) 9147-3749, e-mail: gabriela.gaspar@ufpe.br.",
+    "Antes de decidir participar, leia atentamente este termo. Todas as dúvidas poderão ser esclarecidas com a equipe de pesquisa pelos contatos informados. A participação somente será iniciada após o registro do consentimento eletrônico, realizado por meio da seleção da opção “Aceito participar da pesquisa” na plataforma virtual. Caso não concorde, basta selecionar a opção “Não aceito participar da pesquisa” ou fechar a página, sem qualquer prejuízo.",
+    "O(a) Sr.(a) é livre para aceitar ou recusar a participação. Mesmo após aceitar, poderá retirar seu consentimento a qualquer momento, sem penalidade, constrangimento ou prejuízo de qualquer natureza. Para solicitar a retirada, basta entrar em contato com a equipe de pesquisa por e-mail ou telefone.",
+];
+
+export const censoTermSections: CensoTermSection[] = [
+    {
+        heading: "1. Informações sobre a pesquisa",
+        paragraphs: [
+            "Esta pesquisa tem como objetivo conhecer as condições de estrutura e funcionamento dos Centros de Especialidades Odontológicas (CEO) e dos Serviços de Especialidades Odontológicas (SESB) em todo o Brasil, para subsidiar propostas de melhoria na organização e na gestão desses serviços no âmbito do Sistema Único de Saúde (SUS).",
+            "A coleta de dados será realizada exclusivamente em ambiente virtual, por meio de questionário online disponível na plataforma GestBucal SD. A sua participação consistirá em responder, uma única vez, perguntas sobre a estrutura, os equipamentos, os insumos, os processos de trabalho e o funcionamento do serviço onde atua.",
+            "O preenchimento poderá ser feito de qualquer local com acesso à internet, no horário e no dispositivo de sua preferência, como computador, tablet ou celular. Não haverá encontros presenciais, deslocamentos ou necessidade de assinatura física deste documento. O tempo estimado para resposta é de aproximadamente 30 minutos.",
+        ],
+    },
+    {
+        heading: "2. Procedimento para consentimento eletrônico",
+        paragraphs: [
+            "Ao acessar a plataforma, este TCLE será apresentado antes do início do questionário. Para prosseguir, o(a) participante deverá confirmar que leu as informações, teve oportunidade de esclarecer dúvidas e concorda em participar voluntariamente da pesquisa. O aceite eletrônico será registrado pela plataforma como manifestação livre e esclarecida de consentimento.",
+            "Recomenda-se que o(a) participante salve ou imprima uma cópia deste TCLE para seus registros. Caso necessário, a equipe de pesquisa poderá encaminhar nova cópia por e-mail.",
+        ],
+    },
+    {
+        heading: "3. Riscos",
+        paragraphs: [
+            "RISCOS: A participação poderá gerar desconforto relacionado ao tempo necessário para preenchimento do questionário ou eventual dúvida sobre alguma informação solicitada. Também existe a possibilidade, ainda que remota, de acesso indevido às informações registradas em ambiente digital.",
+            "Para reduzir esses riscos, o questionário foi organizado de forma objetiva e com navegação simples; o tempo estimado será informado antes do início; o(a) participante poderá interromper sua participação a qualquer momento; e os dados serão armazenados em ambiente digital seguro, com acesso restrito à equipe de pesquisa, protegido por autenticação e tratado em conformidade com a Lei Geral de Proteção de Dados Pessoais - LGPD (Lei nº 13.709/2018).",
+        ],
+    },
+    {
+        heading: "4. Benefícios",
+        paragraphs: [
+            "BENEFÍCIOS: A pesquisa não prevê benefícios diretos e imediatos ao(à) participante. No entanto, as informações fornecidas contribuirão para que gestores, pesquisadores e formuladores de políticas públicas conheçam melhor a realidade dos serviços odontológicos especializados no Brasil, podendo subsidiar melhorias no acesso, na organização e na qualidade da atenção em saúde bucal ofertada pelo SUS.",
+        ],
+    },
+    {
+        heading: "5. Confidencialidade, privacidade e armazenamento dos dados",
+        paragraphs: [
+            "Todas as informações obtidas por meio do questionário serão tratadas de forma confidencial. Os dados ficarão armazenados em ambiente digital seguro, com acesso restrito e protegido por autenticação, acessível apenas aos pesquisadores responsáveis pelo estudo.",
+            "Para preservar a privacidade dos participantes, cada respondente será identificado por código, de modo que nome e dados pessoais não apareçam nos arquivos de análise. Os resultados serão divulgados em relatórios, eventos ou publicações científicas sempre de forma agrupada, sem identificação individual dos participantes ou dos serviços, salvo autorização expressa quando aplicável.",
+            "Os dados ficarão sob responsabilidade do pesquisador Paulo Sávio Angeiras de Góes, no endereço Av. da Engenharia s/n, Departamento de Clínica e Odontologia Preventiva, Centro de Ciências da Saúde, UFPE, Recife-PE, CEP: 50670-420, pelo período mínimo de 5 (cinco) anos após o encerramento da pesquisa.",
+        ],
+    },
+    {
+        heading: "6. Custos, ressarcimento e indenização",
+        paragraphs: [
+            "Nada será cobrado nem pago pela participação nesta pesquisa, pois a aceitação é voluntária. Como a coleta será virtual, não estão previstos deslocamentos ou despesas presenciais. Caso haja alguma despesa diretamente relacionada à participação e previamente acordada com a equipe de pesquisa, poderá ser solicitado ressarcimento. Fica garantido o direito à indenização em caso de danos comprovadamente decorrentes da participação na pesquisa, conforme decisão judicial ou extrajudicial.",
+        ],
+    },
+    {
+        heading: "7. Dúvidas e contato com o Comitê de Ética",
+        paragraphs: [
+            "Em caso de dúvidas sobre a pesquisa, o(a) participante poderá entrar em contato com os pesquisadores responsáveis pelos telefones e e-mails informados no início deste documento.",
+            "Em caso de dúvidas relacionadas aos aspectos éticos deste estudo, o(a) Sr.(a) poderá consultar o Comitê de Ética em Pesquisa Envolvendo Seres Humanos da UFPE, no endereço: Avenida da Engenharia s/n, 1º andar, sala 4, Cidade Universitária, Recife-PE, CEP: 50740-600, telefone: (81) 2126-8588, e-mail: cephumanos.ufpe@ufpe.br.",
+        ],
+    },
+];
+
+export const censoTermDeclarationHeading = "8. Declaração de consentimento eletrônico";
+export const censoTermDeclarationIntro =
+    "Ao selecionar uma das opções abaixo, declaro que li este Termo de Consentimento Livre e Esclarecido, tive oportunidade de esclarecer minhas dúvidas e manifesto minha decisão de forma livre e esclarecida:";
+
+export const censoTermAcceptLabel =
+    "Aceito participar da pesquisa e autorizo o uso das informações prestadas para os fins descritos neste TCLE.";
+export const censoTermDeclineLabel = "Não aceito participar da pesquisa.";
+
+export const censoTermResearcher = "Paulo Sávio Angeiras de Góes — Pesquisador responsável — UFPE";

--- a/src/core/enums.ts
+++ b/src/core/enums.ts
@@ -23,6 +23,7 @@ export enum routerEnum {
     APS = "/apsdata",
     USER = "/userdata",
     TCLE = "/tcle",
+    TCLE_CENSO = "/tcle-censo",
     DIRECTION = "/direction",
     DATAFORM = "/dataform",
 }
@@ -39,6 +40,7 @@ export enum titleEnumPtBr {
     "/" = "Início",
     "/home" = "Início",
     "/tcle" = "TCLE",
+    "/tcle-censo" = "TCLE do Censo",
     "/direction" = "Endereço",
     "/form" = "Formularios",
     // "/question" = "Questionario inicial",
@@ -53,6 +55,11 @@ export enum localStorageKeyEnum {
     TOKEN = "token",
     TYPE_ID = "typeId",
     USER_ID = "userId",
+    CENSO_TCLE_STATUS = "censoTcleStatus",
+}
+
+export enum emitterWindowEventEnum {
+    LOGIN_SUCCESS = "gb:login-success",
 }
 
 export enum loginTypeEnum {


### PR DESCRIPTION
Add a mandatory consent modal for the CEO/SESB census TCLE, shown right after login/signup. Requires reading the full term before choosing to accept or decline; declining logs the user out after a 10s countdown (or immediately on demand). Also adds a standalone /tcle-censo page with the full term text and a footer link to it.

Consent state is tracked in localStorage per user for now, with a placeholder POST to /term/censo/send for backend persistence once that endpoint exists.